### PR TITLE
fix(swap): consume per-hop fees[i] — remove hardcoded 0.3% (997/1000)

### DIFF
--- a/contracts/main/BofhContractV2.sol
+++ b/contracts/main/BofhContractV2.sol
@@ -21,8 +21,10 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @notice Uniswap V2-style factory address for pair lookups
     address private immutable factory;
 
-    /// @notice Maximum allowed fee in basis points (100% = 10000 bps)
-    uint256 private constant MAX_FEE_BPS = 10000;
+    /// @notice Maximum allowed per-hop fee in basis points out of 10000 (10% = 1000 bps)
+    /// @dev Tightened from 10000 (100%) to 1000 (10%): rejects absurd fees while still covering
+    /// @dev real-world DEX forks. Per-fee validation in _validateSwapInputs enforces this cap.
+    uint256 private constant MAX_FEE_BPS = 1000;
 
     /// @notice Internal state tracking for multi-step swap execution
     /// @dev Minimal state for tracking swap progress across multiple hops
@@ -66,7 +68,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @notice Validate all swap parameters before execution
     /// @dev Comprehensive validation: deadline, array lengths, amounts, addresses, path structure, fees
     /// @dev Validates: 1) Deadline not expired, 2) Arrays correct length, 3) Amounts > 0,
-    /// @dev 4) Addresses non-zero, 5) Path starts/ends with baseToken, 6) Fees ≤ 100%
+    /// @dev 4) Addresses non-zero, 5) Path starts/ends with baseToken, 6) Fees ≤ MAX_FEE_BPS (10%)
     /// @param path Token swap path (must start and end with baseToken)
     /// @param fees Fee array in basis points (length = path.length - 1)
     /// @param amountIn Input amount (must be > 0)
@@ -106,7 +108,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         address cachedBaseToken = baseToken;
         if (path[0] != cachedBaseToken || path[pathLength - 1] != cachedBaseToken) revert InvalidPath();
 
-        // 6. Fee validation (fees must be reasonable, max 100% = 10000 bps)
+        // 6. Fee validation (fees must be reasonable, max MAX_FEE_BPS = 1000 bps = 10%)
         for (uint256 i = 0; i < fees.length;) {
             if (fees[i] > MAX_FEE_BPS) revert InvalidFee();
             unchecked { ++i; }
@@ -182,7 +184,8 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             state = executePathStep(
                 state,
                 path[i],
-                path[i + 1]
+                path[i + 1],
+                fees[i]
             );
 
             unchecked {
@@ -365,14 +368,23 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @param state Current swap state (token, amount, impact)
     /// @param tokenIn Input token address for this step
     /// @param tokenOut Output token address for this step
+    /// @param feeBps Per-hop swap fee in basis points out of 10000 (e.g. 30 = 0.3%, 25 = 0.25%)
     /// @return Updated swap state with new currentAmount and cumulativeImpact
     /// @custom:security Validates pool liquidity and calculates price impact before swap
-    /// @custom:optimization Removed unused parameters (fee, stepIndex, pathLength) for gas savings
+    /// @custom:optimization Removed unused parameters (stepIndex, pathLength) for gas savings
+    /// @custom:fee Consumes the caller-supplied per-hop fee so the router prices correctly on
+    /// @custom:fee DEXes with non-0.3% fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks)
     function executePathStep(
         SwapState memory state,
         address tokenIn,
-        address tokenOut
+        address tokenOut,
+        uint256 feeBps
     ) private returns (SwapState memory) {
+        // Defense-in-depth: the assembly below computes (10000 - feeBps). Callers reach this
+        // private helper only via _validateSwapInputs (which enforces fees[i] <= MAX_FEE_BPS),
+        // but re-check here so the subtraction can never underflow if a future caller forgets.
+        if (feeBps > MAX_FEE_BPS) revert InvalidFee();
+
         // Get the pair address for these two tokens
         address pairAddress = _getPair(tokenIn, tokenOut);
 
@@ -397,7 +409,9 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         if (!PoolLib.validateSwap(pool, params)) revert InvalidSwapParameters();
 
         // Calculate expected output using constant product formula (x * y = k)
-        // amountOut = (amountIn * reserveOut * 997) / (reserveIn * 1000 + amountIn * 997)
+        // amountOut = (amountIn * reserveOut * (10000 - feeBps)) /
+        //             (reserveIn * 10000 + amountIn * (10000 - feeBps))
+        // feeBps is a 10000-basis per-hop fee (30 = 0.3%, reproducing the legacy 997/1000 result).
         // Phase 3 optimization: Assembly for maximum gas efficiency
         uint256 expectedOutput;
         assembly {
@@ -406,14 +420,17 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             let reserveOut := mload(add(pool, 0x20)) // pool.reserveOut (2nd field after reserveIn)
             let reserveIn := mload(pool) // pool.reserveIn (1st field)
 
-            // Calculate: amountInWithFee = amountIn * 997
-            let amountInWithFee := mul(amountIn, 997)
+            // Calculate: feeNum = 10000 - feeBps (feeBps=30 -> 9970, i.e. legacy 0.3%)
+            let feeNum := sub(10000, feeBps)
+
+            // Calculate: amountInWithFee = amountIn * feeNum
+            let amountInWithFee := mul(amountIn, feeNum)
 
             // Calculate: numerator = amountInWithFee * reserveOut
             let numerator := mul(amountInWithFee, reserveOut)
 
-            // Calculate: denominator = reserveIn * 1000 + amountInWithFee
-            let denominator := add(mul(reserveIn, 1000), amountInWithFee)
+            // Calculate: denominator = reserveIn * 10000 + amountInWithFee
+            let denominator := add(mul(reserveIn, 10000), amountInWithFee)
 
             // Calculate: expectedOutput = numerator / denominator
             expectedOutput := div(numerator, denominator)

--- a/contracts/mocks/MockPair.sol
+++ b/contracts/mocks/MockPair.sol
@@ -11,8 +11,8 @@ contract MockPair {
     uint32 private blockTimestampLast;
     
     uint256 private constant MINIMUM_LIQUIDITY = 1000;
-    uint256 private constant FEE_DENOMINATOR = 1000;
-    uint256 public swapFee = 3; // 0.3%
+    uint256 private constant FEE_DENOMINATOR = 10000;
+    uint256 public swapFee = 30; // 0.3% (30/10000); set via setSwapFee for other DEX fees
     
     event Mint(address indexed sender, uint256 amount0, uint256 amount1);
     event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
@@ -45,7 +45,14 @@ contract MockPair {
         _reserve1 = reserve1;
         _blockTimestampLast = blockTimestampLast;
     }
-    
+
+    /// @notice Set the swap fee in basis points out of FEE_DENOMINATOR (10000)
+    /// @dev Test helper to emulate DEXes with different fees (25 = 0.25%, 30 = 0.3%, 50 = 0.5%)
+    /// @param _fee Fee in basis points out of 10000
+    function setSwapFee(uint256 _fee) external {
+        swapFee = _fee;
+    }
+
     function mint(address to) external returns (uint256 liquidity) {
         (uint112 _reserve0, uint112 _reserve1,) = getReserves();
         uint256 balance0 = MockToken(token0).balanceOf(address(this));

--- a/env.json.example
+++ b/env.json.example
@@ -1,4 +1,6 @@
 {
-    "mnemonic": "your twelve word mnemonic phrase goes here for BSC testnet deployment",
-    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE"
+    "mnemonic": "your twelve word mnemonic phrase goes here for deployment",
+    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE",
+    "_comment_explorers": "Keys for non-BSC explorers are read from environment variables, not from this file: POLYGONSCAN_API_KEY, BASESCAN_API_KEY (and BSCSCAN_API_KEY overrides the value above).",
+    "_comment_rpc": "RPC endpoints and the EVM target are env-overridable too: BSC_RPC, BSC_TESTNET_RPC, POLYGON_RPC, POLYGON_AMOY_RPC, BASE_RPC, BASE_SEPOLIA_RPC, EVM_VERSION. See hardhat.config.js."
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@
 require("@nomicfoundation/hardhat-ethers");
 require("@nomicfoundation/hardhat-chai-matchers");
 require("@nomicfoundation/hardhat-network-helpers");
+require("@nomicfoundation/hardhat-verify");
 require("hardhat-gas-reporter");
 require("solidity-coverage");
 
@@ -20,11 +21,23 @@ try {
   BSCSCANAPIKEY = "placeholder";
 }
 
+// Shared signer config for all live networks
+const accounts = { mnemonic };
+
+// Per-chain block-explorer API keys (env-overridable; fall back to env.json's BSCSCANAPIKEY for BSC)
+const BSCSCAN_KEY = process.env.BSCSCAN_API_KEY || BSCSCANAPIKEY;
+const POLYGONSCAN_KEY = process.env.POLYGONSCAN_API_KEY || "placeholder";
+const BASESCAN_KEY = process.env.BASESCAN_API_KEY || "placeholder";
+
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {
     version: "0.8.10",
     settings: {
+      // Pin the EVM target: solc 0.8.10 defaults to "london" (PUSH0-free). Pinning prevents a
+      // future solc bump from silently emitting PUSH0/MCOPY and bricking deploys on chains that
+      // lag Shanghai/Cancun. Override per-chain via EVM_VERSION (e.g. "paris", "cancun").
+      evmVersion: process.env.EVM_VERSION || "london",
       optimizer: {
         enabled: true,
         runs: 200
@@ -32,6 +45,8 @@ module.exports = {
     }
   },
 
+  // EVM-compatible networks. RPC URLs are env-overridable; all use the same mnemonic-derived signer.
+  // Adding a chain = one entry here + (for verification) one apiKey below.
   networks: {
     // Local Hardhat network (replaces Ganache)
     hardhat: {
@@ -42,28 +57,43 @@ module.exports = {
       }
     },
 
-    // BSC Testnet (Chain ID: 97)
+    // --- BNB Smart Chain ---
     bscTestnet: {
-      url: "https://data-seed-prebsc-1-s1.binance.org:8545",
+      url: process.env.BSC_TESTNET_RPC || "https://data-seed-prebsc-1-s1.binance.org:8545",
       chainId: 97,
-      accounts: {
-        mnemonic: mnemonic
-      },
+      accounts,
       gasPrice: 10000000000, // 10 gwei
-      timeout: 100000,
-      confirmations: 10
+      timeout: 100000
+    },
+    bsc: {
+      url: process.env.BSC_RPC || "https://bsc-dataseed1.binance.org",
+      chainId: 56,
+      accounts
     },
 
-    // BSC Mainnet (Chain ID: 56) - disabled for now
-    // bscMainnet: {
-    //   url: "https://bsc-dataseed1.binance.org",
-    //   chainId: 56,
-    //   accounts: {
-    //     mnemonic: mnemonic
-    //   },
-    //   gasPrice: 5000000000, // 5 gwei
-    //   confirmations: 10
-    // }
+    // --- Polygon PoS ---
+    polygon: {
+      url: process.env.POLYGON_RPC || "https://polygon-rpc.com",
+      chainId: 137,
+      accounts
+    },
+    polygonAmoy: {
+      url: process.env.POLYGON_AMOY_RPC || "https://rpc-amoy.polygon.technology",
+      chainId: 80002,
+      accounts
+    },
+
+    // --- Base ---
+    base: {
+      url: process.env.BASE_RPC || "https://mainnet.base.org",
+      chainId: 8453,
+      accounts
+    },
+    baseSepolia: {
+      url: process.env.BASE_SEPOLIA_RPC || "https://sepolia.base.org",
+      chainId: 84532,
+      accounts
+    }
   },
 
   // Gas reporter configuration
@@ -75,11 +105,15 @@ module.exports = {
     noColors: true
   },
 
-  // Etherscan verification
+  // Block-explorer verification (hardhat-verify). Per-chain keys, env-overridable.
   etherscan: {
     apiKey: {
-      bscTestnet: BSCSCANAPIKEY,
-      bsc: BSCSCANAPIKEY
+      bsc: BSCSCAN_KEY,
+      bscTestnet: BSCSCAN_KEY,
+      polygon: POLYGONSCAN_KEY,
+      polygonAmoy: POLYGONSCAN_KEY,
+      base: BASESCAN_KEY,
+      baseSepolia: BASESCAN_KEY
     }
   },
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,6 +1,7 @@
 const hre = require('hardhat');
 const { ethers } = require('hardhat');
 const { loadDeployment, waitForTx, parseAmount } = require('./utils/helpers');
+const { isTestNetwork, isLocalNetwork } = require('./utils/addresses');
 
 async function main() {
   console.log('\n⚙️  Starting contract configuration...\n');
@@ -32,37 +33,28 @@ async function main() {
   // ==================================================================
   console.log('📊 STEP 1: Configuring Risk Parameters\n');
 
-  // Different parameters for different networks
-  let riskParams;
-  if (networkName === 'bsc') {
-    // Production mainnet - conservative parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('100', 6),      // 100 tokens (in PRECISION units)
-      minPoolLiquidity: parseAmount('50', 6),     // 50 tokens minimum
-      maxPriceImpact: parseAmount('0.05', 6),     // 5% max price impact
-      sandwichProtectionBips: 25                   // 0.25% sandwich protection
-    };
-    console.log('   Using PRODUCTION parameters (conservative)');
-  } else if (networkName === 'bscTestnet') {
-    // Testnet - moderate parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('1000', 6),     // 1000 tokens
-      minPoolLiquidity: parseAmount('100', 6),    // 100 tokens minimum
-      maxPriceImpact: parseAmount('0.10', 6),     // 10% max price impact
-      sandwichProtectionBips: 50                   // 0.5% sandwich protection
-    };
-    console.log('   Using TESTNET parameters (moderate)');
-  } else {
-    // Local/hardhat - permissive for testing
-    riskParams = {
-      maxTradeVolume: parseAmount('10000', 6),    // 10000 tokens
-      minPoolLiquidity: parseAmount('10', 6),     // 10 tokens minimum
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact (corrected typo)
-      sandwichProtectionBips: 100                  // 1% sandwich protection
-    };
-    console.log('   Using LOCAL parameters (permissive for testing)');
-  }
+  // Risk tiers, selected from network metadata (not hardcoded names). Any unknown LIVE
+  // network falls through to the conservative mainnet tier — never the permissive one.
+  const RISK_TIERS = {
+    mainnet: { maxTradeVolume: '100',   minPoolLiquidity: '50',  maxPriceImpact: '0.05', sandwichProtectionBips: 25,  label: 'PRODUCTION (conservative)' },
+    testnet: { maxTradeVolume: '1000',  minPoolLiquidity: '100', maxPriceImpact: '0.10', sandwichProtectionBips: 50,  label: 'TESTNET (moderate)' },
+    local:   { maxTradeVolume: '10000', minPoolLiquidity: '10',  maxPriceImpact: '0.20', sandwichProtectionBips: 100, label: 'LOCAL (permissive for testing)' }
+  };
+
+  const tierName = isLocalNetwork(networkName)
+    ? 'local'
+    : isTestNetwork(networkName)
+      ? 'testnet'
+      : 'mainnet'; // unknown live network -> conservative, not permissive
+  const tier = RISK_TIERS[tierName];
+
+  const riskParams = {
+    maxTradeVolume: parseAmount(tier.maxTradeVolume, 6),
+    minPoolLiquidity: parseAmount(tier.minPoolLiquidity, 6),
+    maxPriceImpact: parseAmount(tier.maxPriceImpact, 6),
+    sandwichProtectionBips: tier.sandwichProtectionBips
+  };
+  console.log(`   Using ${tier.label} parameters`);
 
   console.log('\n   Parameters:');
   console.log(`      Max Trade Volume: ${ethers.formatUnits(riskParams.maxTradeVolume, 6)}`);

--- a/scripts/utils/addresses.js
+++ b/scripts/utils/addresses.js
@@ -1,10 +1,17 @@
-// Network addresses for BofhContract deployment
+// Network address book for BofhContract deployment.
+//
+// Multi-chain by design: each EVM network has an entry in CHAIN_META (wrapped-native
+// symbol, default DEX, testnet flag) plus token/factory tables below. Adding a chain =
+// add one CHAIN_META entry + the wrapped-native address in TOKENS + a factory in FACTORIES.
+// Local networks (hardhat/localhost) intentionally have no static addresses — their
+// tokens/factories are mock contracts deployed at runtime by scripts/deploy.js.
 
 /**
- * Known token addresses on different networks
+ * Known token addresses per network. Keys are token symbols; the wrapped-native symbol
+ * for each chain is declared in CHAIN_META and resolved by getBaseToken().
  */
 const TOKENS = {
-  // BSC Mainnet
+  // --- BNB Smart Chain ---
   bsc: {
     WBNB: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
     BUSD: '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
@@ -13,8 +20,6 @@ const TOKENS = {
     ETH: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
     CAKE: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82'
   },
-
-  // BSC Testnet
   bscTestnet: {
     WBNB: '0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd',
     BUSD: '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', // BUSD-T
@@ -23,90 +28,144 @@ const TOKENS = {
     CAKE: '0xFa60D973F7642B748046464e165A65B7323b0DEE'  // CAKE-T
   },
 
-  // Local Hardhat (deployed mocks)
-  hardhat: {
-    // Will be populated during deployment
+  // --- Polygon PoS ---
+  polygon: {
+    WMATIC: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+    USDC: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', // USDC.e (bridged)
+    USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    WETH: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+  },
+  polygonAmoy: {
+    // Fill wrapped-native (WMATIC) + tokens per deployment target.
   },
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  // --- Base ---
+  base: {
+    WETH: '0x4200000000000000000000000000000000000006',
+    USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  },
+  baseSepolia: {
+    // Fill wrapped-native (WETH) + tokens per deployment target.
+  },
+
+  // --- Local (mocks deployed at runtime) ---
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Known factory addresses (Uniswap V2 / PancakeSwap style)
+ * Known factory addresses (Uniswap V2 / PancakeSwap-style) per network and DEX.
  */
 const FACTORIES = {
-  // BSC Mainnet
   bsc: {
     PancakeSwapV2: '0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73',
     BiswapV2: '0x858E3312ed3A876947EA49d572A7C42DE08af7EE',
     ApeSwapV2: '0x0841BD0B734E4F5853f0dD8d7Ea041c241fb0Da6'
   },
-
-  // BSC Testnet
   bscTestnet: {
     PancakeSwapV2: '0x6725F303b657a9451d8BA641348b6761A6CC7a17'
   },
 
-  // Local Hardhat (deployed mock)
-  hardhat: {
-    // Will be populated during deployment
+  polygon: {
+    QuickSwapV2: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
+    SushiSwapV2: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4'
   },
+  polygonAmoy: {},
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  base: {
+    UniswapV2: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6'
+  },
+  baseSepolia: {},
+
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Get base token address for a network
- * @param {string} networkName - Name of the network (hardhat, bscTestnet, bsc)
- * @returns {string} Base token address (WBNB or mock)
+ * Per-chain metadata. `wrappedNative` is the TOKENS key used as the swap base token;
+ * `defaultDex` is the FACTORIES key used when no DEX is specified; `isTestnet` drives
+ * isTestNetwork(); `local` marks networks whose addresses are mock-deployed at runtime.
+ */
+const CHAIN_META = {
+  bsc:         { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: false },
+  bscTestnet:  { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: true  },
+  polygon:     { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: false },
+  polygonAmoy: { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: true  },
+  base:        { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: false },
+  baseSepolia: { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: true  },
+  hardhat:     { isTestnet: true, local: true },
+  localhost:   { isTestnet: true, local: true }
+};
+
+const LOCAL_NETWORKS = ['hardhat', 'localhost'];
+
+/**
+ * True for local dev networks whose contracts are mock-deployed at runtime.
+ * @param {string} networkName
+ * @returns {boolean}
+ */
+function isLocalNetwork(networkName) {
+  return LOCAL_NETWORKS.includes(networkName);
+}
+
+/**
+ * Get the wrapped-native (base) token address for a network.
+ * @param {string} networkName
+ * @returns {string} Wrapped-native token address
  */
 function getBaseToken(networkName) {
-  if (networkName === 'bsc') {
-    return TOKENS.bsc.WBNB;
-  } else if (networkName === 'bscTestnet') {
-    return TOKENS.bscTestnet.WBNB;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Base token for ${networkName} must be deployed first`);
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Base token for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/TOKENS in scripts/utils/addresses.js`);
+  }
+  const addr = (TOKENS[networkName] || {})[meta.wrappedNative];
+  if (!addr) {
+    throw new Error(`Wrapped-native (${meta.wrappedNative}) address not set for "${networkName}" in TOKENS`);
+  }
+  return addr;
 }
 
 /**
- * Get factory address for a network
- * @param {string} networkName - Name of the network
- * @param {string} dex - DEX name (default: PancakeSwapV2)
+ * Get a factory address for a network and DEX (defaults to the chain's default DEX).
+ * @param {string} networkName
+ * @param {string} [dex] - DEX name; defaults to CHAIN_META[networkName].defaultDex
  * @returns {string} Factory address
  */
-function getFactory(networkName, dex = 'PancakeSwapV2') {
-  if (networkName === 'bsc' || networkName === 'bscTestnet') {
-    const factory = FACTORIES[networkName][dex];
-    if (!factory) {
-      throw new Error(`Factory ${dex} not found for network ${networkName}`);
-    }
-    return factory;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Factory for ${networkName} must be deployed first`);
+function getFactory(networkName, dex) {
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Factory for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/FACTORIES in scripts/utils/addresses.js`);
+  }
+  const dexName = dex || meta.defaultDex;
+  const addr = (FACTORIES[networkName] || {})[dexName];
+  if (!addr) {
+    throw new Error(`Factory "${dexName}" not set for "${networkName}" in FACTORIES`);
+  }
+  return addr;
 }
 
 /**
- * Check if network is a testnet/local network
- * @param {string} networkName - Name of the network
- * @returns {boolean} True if testnet or local
+ * Whether a network is a testnet or local network (derived from CHAIN_META, not a hardcoded list).
+ * @param {string} networkName
+ * @returns {boolean}
  */
 function isTestNetwork(networkName) {
-  return ['hardhat', 'localhost', 'bscTestnet'].includes(networkName);
+  const meta = CHAIN_META[networkName];
+  return meta ? Boolean(meta.isTestnet) : false;
 }
 
 module.exports = {
   TOKENS,
   FACTORIES,
+  CHAIN_META,
   getBaseToken,
   getFactory,
-  isTestNetwork
+  isTestNetwork,
+  isLocalNetwork
 };

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,5 +1,16 @@
 const hre = require('hardhat');
 const { loadDeployment, verifyContract, delay } = require('./utils/helpers');
+const { isLocalNetwork } = require('./utils/addresses');
+
+// Block-explorer base URLs per network (used only for the post-verification link).
+const EXPLORERS = {
+  bsc: 'https://bscscan.com',
+  bscTestnet: 'https://testnet.bscscan.com',
+  polygon: 'https://polygonscan.com',
+  polygonAmoy: 'https://amoy.polygonscan.com',
+  base: 'https://basescan.org',
+  baseSepolia: 'https://sepolia.basescan.org'
+};
 
 async function main() {
   console.log('\n🔍 Starting contract verification...\n');
@@ -17,9 +28,10 @@ async function main() {
 
   console.log(`📝 Loaded deployment from: deployments/${networkName}.json\n`);
 
-  // Only verify on public networks
-  if (networkName !== 'bscTestnet' && networkName !== 'bsc') {
-    console.log('ℹ️  Verification only available for bscTestnet and bsc networks');
+  // Skip verification only on local networks (no public explorer). Any live EVM
+  // network is supported via hardhat-verify + the per-chain etherscan config.
+  if (isLocalNetwork(networkName)) {
+    console.log('ℹ️  Skipping verification on local network');
     process.exit(0);
   }
 
@@ -93,12 +105,11 @@ async function main() {
   console.log(`   PoolLib: ${deployment.libraries.PoolLib}`);
   console.log(`   BofhContractV2: ${deployment.contracts.BofhContractV2}`);
 
-  const explorerUrl = networkName === 'bscTestnet'
-    ? 'https://testnet.bscscan.com'
-    : 'https://bscscan.com';
-
-  console.log(`\n🔗 View on BSCScan:`);
-  console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  const explorerUrl = EXPLORERS[networkName];
+  if (explorerUrl) {
+    console.log(`\n🔗 View on explorer:`);
+    console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  }
   console.log('='.repeat(60) + '\n');
 }
 

--- a/test/BatchSwaps.test.js
+++ b/test/BatchSwaps.test.js
@@ -130,7 +130,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -150,7 +150,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -171,7 +171,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: expiredDeadline,
@@ -192,7 +192,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [tokenAAddr, baseAddr], // Invalid: doesn't start with base
-          fees: [300],
+          fees: [30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -213,7 +213,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr], // Invalid: doesn't end with base
-          fees: [300],
+          fees: [30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -236,7 +236,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -264,7 +264,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: amountIn,
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -288,7 +288,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -296,7 +296,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -333,7 +333,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -341,7 +341,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -349,7 +349,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenCAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -384,7 +384,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -424,7 +424,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -432,7 +432,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('999999'), // Impossible to achieve
           deadline: deadline,
@@ -463,7 +463,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: validDeadline,
@@ -471,7 +471,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: expiredDeadline, // Expired
@@ -494,7 +494,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -517,7 +517,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -525,7 +525,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -548,7 +548,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -577,7 +577,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -622,7 +622,7 @@ describe('Batch Swap Execution Tests', function () {
         {
           // 2-hop path
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -631,7 +631,7 @@ describe('Batch Swap Execution Tests', function () {
         {
           // 3-hop path
           path: [baseAddr, tokenAAddr, tokenBAddr, baseAddr],
-          fees: [300, 300, 300],
+          fees: [30, 30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('90'),
           deadline: deadline,

--- a/test/BofhContractV2.test.js
+++ b/test/BofhContractV2.test.js
@@ -191,7 +191,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     [],
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -212,7 +212,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n], // Wrong length - should be path.length - 1
+                    [30n], // Wrong length - should be path.length - 1
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -233,7 +233,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     0n,
                     MIN_OUT,
                     deadline
@@ -254,7 +254,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     0n,
                     deadline
@@ -275,7 +275,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     pastDeadline
@@ -296,7 +296,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -317,7 +317,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -338,7 +338,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [10001n, 3000n], // > 100% fee
+                    [1001n, 30n], // > MAX_FEE_BPS (1000 = 10%) -> InvalidFee
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -363,7 +363,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n, 3000n, 3000n, 3000n],
+                    [30n, 30n, 30n, 30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -458,7 +458,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     pastDeadline
@@ -503,7 +503,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline

--- a/test/FeePortability.test.js
+++ b/test/FeePortability.test.js
@@ -1,0 +1,203 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Fee-portability tests for the "fee fix".
+ *
+ * The router used to hardcode the 0.3% (997/1000) AMM fee. It now consumes the
+ * per-hop `fees[i]` (basis points out of 10000), so it prices correctly on DEXes
+ * with other fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks).
+ *
+ * These tests deploy MockToken / MockFactory / MockPair, fund pools, set the
+ * MockPair swapFee to emulate a given DEX, and verify:
+ *   (a) a 0.25% pair priced at feeBps=25 swaps successfully (no K-revert) and the
+ *       realized output equals the contract's constant-product amount-out;
+ *   (b) a 0.5% pair priced at feeBps=30 (too low) requests more than x*y=k allows
+ *       and reverts;
+ *   (c) the SAME path/amount through a 0.25% pool yields MORE than through a 0.30%
+ *       pool (fee sensitivity).
+ */
+describe("Fee Portability (per-hop fee consumption)", function () {
+  // Constant-product amount-out, identical to the formula the router computes
+  // in executePathStep: amountOut = (amountIn * (10000-feeBps) * reserveOut) /
+  //                                 (reserveIn * 10000 + amountIn * (10000-feeBps))
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    const numerator = amountInWithFee * reserveOut;
+    const denominator = reserveIn * 10000n + amountInWithFee;
+    return numerator / denominator;
+  }
+
+  async function deployFixture() {
+    const [owner, user1] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    // tokenA reachable via the "0.25% / variable-fee" pool, tokenB via a fixed 0.30% pool
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+    const tokenB = await MockToken.deploy("Token B", "TKNB", ethers.parseEther("100000000"));
+
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory = await MockFactory.deploy();
+
+    await factory.createPair(await baseToken.getAddress(), await tokenA.getAddress());
+    await factory.createPair(await baseToken.getAddress(), await tokenB.getAddress());
+
+    const pairBaseAAddr = await factory.getPair(await baseToken.getAddress(), await tokenA.getAddress());
+    const pairBaseBAddr = await factory.getPair(await baseToken.getAddress(), await tokenB.getAddress());
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pairBaseA = MockPair.attach(pairBaseAAddr);
+    const pairBaseB = MockPair.attach(pairBaseBAddr);
+
+    // Symmetric, deep liquidity so the round-trip BASE -> X -> BASE only loses to fees
+    // (no asymmetric-reserve effects) and so K-checks are well within uint112.
+    const liquidity = ethers.parseEther("1000000");
+
+    await baseToken.transfer(pairBaseAAddr, liquidity);
+    await tokenA.transfer(pairBaseAAddr, liquidity);
+    await pairBaseA.sync();
+
+    await baseToken.transfer(pairBaseBAddr, liquidity);
+    await tokenB.transfer(pairBaseBAddr, liquidity);
+    await pairBaseB.sync();
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const bofh = await BofhContractV2.deploy(
+      await baseToken.getAddress(),
+      await factory.getAddress()
+    );
+
+    await baseToken.transfer(user1.address, ethers.parseEther("100000"));
+    await baseToken.connect(user1).approve(await bofh.getAddress(), ethers.MaxUint256);
+
+    return {
+      bofh,
+      baseToken,
+      tokenA,
+      tokenB,
+      factory,
+      pairBaseA,
+      pairBaseB,
+      pairBaseAAddr,
+      liquidity,
+      owner,
+      user1,
+      getAmountOut,
+    };
+  }
+
+  describe("(a) 0.25% pair priced at feeBps=25", function () {
+    it("Should swap successfully and match the contract's constant-product amount-out", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, liquidity, user1 } =
+        await loadFixture(deployFixture);
+
+      // Emulate a Pancake-style 0.25% pool.
+      await pairBaseA.setSwapFee(25);
+      expect(await pairBaseA.swapFee()).to.equal(25);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [25, 25]; // price both hops at the pool's true 0.25% fee
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      // Compute the expected realized output hop-by-hop using the same formula as the router.
+      // Hop 1: BASE -> A, reserves (reserveIn=BASE=liquidity, reserveOut=A=liquidity).
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 25);
+      // Hop 2: A -> BASE on the SAME pool, reserves updated by hop 1:
+      //   the pool gained `amountIn` BASE and lost `out1` A, so now
+      //   reserveIn (A) = liquidity - out1, reserveOut (BASE) = liquidity + amountIn.
+      const out2 = getAmountOut(out1, liquidity - out1, liquidity + amountIn, 25);
+
+      const balanceBefore = await baseToken.balanceOf(user1.address);
+      // Succeeds (no "K" revert) because the requested output respects x*y=k at 0.25%.
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.not.be.reverted;
+      const balanceAfter = await baseToken.balanceOf(user1.address);
+
+      // Net delta = realized round-trip output - amountIn spent.
+      const realizedOutput = balanceAfter - balanceBefore + amountIn;
+      expect(realizedOutput).to.equal(out2);
+    });
+  });
+
+  describe("(b) 0.5% pair", function () {
+    it("priced correctly at feeBps=50 should succeed where the legacy hardcoded-0.3% router could not", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, liquidity, user1 } =
+        await loadFixture(deployFixture);
+
+      // Emulate a 0.5% pool and price the caller at its TRUE fee. This is the assertion
+      // that DISCRIMINATES the fix from the bug: the old router (hardcoded 997/1000 = 0.3%)
+      // would size a 0.3% output and revert "K" on a 0.5% pool; the fee-aware router sizes
+      // the output for 0.5% and succeeds.
+      await pairBaseA.setSwapFee(50);
+      expect(await pairBaseA.swapFee()).to.equal(50);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [50, 50];
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 50);
+      const out2 = getAmountOut(out1, liquidity - out1, liquidity + amountIn, 50);
+
+      const balanceBefore = await baseToken.balanceOf(user1.address);
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.not.be.reverted;
+      const balanceAfter = await baseToken.balanceOf(user1.address);
+
+      const realizedOutput = balanceAfter - balanceBefore + amountIn;
+      expect(realizedOutput).to.equal(out2);
+    });
+
+    it("under-priced at feeBps=30 should revert with \"K\" (router requests more than x*y=k allows)", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, user1 } = await loadFixture(deployFixture);
+
+      // Pool actually charges 0.5%, but the caller prices it as 0.3%: the router computes a
+      // 0.3%-sized output the pool's K-invariant won't release, so MockPair.swap() reverts "K".
+      await pairBaseA.setSwapFee(50);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [30, 30]; // under-priced vs the pool's real 0.5% fee
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.be.revertedWith("K");
+    });
+  });
+
+  describe("(c) Fee sensitivity: 0.25% vs 0.30%", function () {
+    it("Should yield MORE output through a 0.25% pool than a 0.30% pool for the same path/amount", async function () {
+      const { bofh, baseToken, tokenA, tokenB, pairBaseA, pairBaseB, user1 } =
+        await loadFixture(deployFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      // Path via tokenA pool at 0.25%
+      await pairBaseA.setSwapFee(25);
+      const pathA = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const balBeforeA = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(pathA, [25, 25], amountIn, 1n, deadline);
+      const balAfterA = await baseToken.balanceOf(user1.address);
+      const outputAt025 = balAfterA - balBeforeA + amountIn;
+
+      // Path via tokenB pool at 0.30% (default), identical reserves
+      await pairBaseB.setSwapFee(30);
+      const pathB = [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()];
+      const balBeforeB = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(pathB, [30, 30], amountIn, 1n, deadline);
+      const balAfterB = await baseToken.balanceOf(user1.address);
+      const outputAt030 = balAfterB - balBeforeB + amountIn;
+
+      // Lower fee -> strictly more output for identical reserves/amount.
+      expect(outputAt025).to.be.greaterThan(outputAt030);
+    });
+  });
+});

--- a/test/GasOptimization.test.js
+++ b/test/GasOptimization.test.js
@@ -88,7 +88,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA, owner } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3]; // 0.3% fee for each hop
+      const fees = [30, 30]; // 0.3% fee for each hop (30/10000)
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -110,7 +110,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -133,7 +133,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3, 3];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -157,7 +157,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3, 3, 3];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -176,7 +176,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -190,7 +190,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("5000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 

--- a/test/MEVProtection.test.js
+++ b/test/MEVProtection.test.js
@@ -127,7 +127,7 @@ describe("MEV Protection Tests", function () {
 
       // MEV protection disabled by default
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -145,7 +145,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).configureMEVProtection(true, 10, 60);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -166,7 +166,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).configureMEVProtection(true, 10, 5);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -188,7 +188,7 @@ describe("MEV Protection Tests", function () {
 
       // MEV protection disabled by default
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("0.5");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -211,7 +211,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).emergencyPause();
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;

--- a/test/Mocks.test.js
+++ b/test/Mocks.test.js
@@ -428,7 +428,7 @@ describe("Mock Contracts", function () {
       it("Should return default swap fee", async function () {
         const { pair } = await loadFixture(deployPairFixture);
 
-        expect(await pair.swapFee()).to.equal(3); // 0.3% default
+        expect(await pair.swapFee()).to.equal(30); // 0.3% default (30/10000)
       });
     });
 

--- a/test/MultiSwap.test.js
+++ b/test/MultiSwap.test.js
@@ -94,7 +94,7 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()],
         [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000]];
+      const fees = [[30, 30], [30, 30]];
       const amounts = [ethers.parseEther("1"), ethers.parseEther("1")];
       const minAmounts = [ethers.parseEther("0.1"), ethers.parseEther("0.1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -113,7 +113,7 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()],
         [await baseToken.getAddress(), await tokenC.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000], [3000, 3000]];
+      const fees = [[30, 30], [30, 30], [30, 30]];
       const amounts = [
         ethers.parseEther("1"),
         ethers.parseEther("1"),
@@ -137,7 +137,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -165,7 +165,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000]]; // Wrong length
+      const fees = [[30, 30], [30, 30]]; // Wrong length
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -181,7 +181,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10"), ethers.parseEther("10")]; // Wrong length
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -197,7 +197,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1"), ethers.parseEther("1")]; // Wrong length
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -213,7 +213,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const pastDeadline = Math.floor(Date.now() / 1000) - 100;
@@ -229,7 +229,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
 
@@ -250,8 +250,8 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenA.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()]
       ];
       const fees = [
-        [3000, 3000],
-        [3000, 3000, 3000]
+        [30, 30],
+        [30, 30, 30]
       ];
       const amounts = [ethers.parseEther("10"), ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1"), ethers.parseEther("1")];

--- a/test/SwapExecution.test.js
+++ b/test/SwapExecution.test.js
@@ -132,7 +132,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1, pairBaseA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000]; // 0.3% fee for each swap
+      const fees = [30, 30]; // 0.3% fee for each swap
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1"); // Conservative minimum (swaps optimize for best output)
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -160,7 +160,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("100"); // Unrealistic expectation
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -174,7 +174,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -195,7 +195,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("9");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -214,7 +214,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -247,7 +247,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("20");
       const minAmountOut = ethers.parseEther("15");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -267,7 +267,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("100");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -292,7 +292,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -315,7 +315,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("50");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -336,7 +336,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("100");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -358,7 +358,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -375,7 +375,7 @@ describe("Swap Execution Tests", function () {
 
       // 2-way swap
       const path2 = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees2 = [3000, 3000];
+      const fees2 = [30, 30];
       const tx2 = await bofh.connect(user1).executeSwap(
         path2,
         fees2,
@@ -395,7 +395,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees5 = [3000, 3000, 3000, 3000, 3000];
+      const fees5 = [30, 30, 30, 30, 30];
       const tx5 = await bofh.connect(user1).executeSwap(
         path5,
         fees5,
@@ -428,7 +428,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("100"); // Large amount for high impact
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;


### PR DESCRIPTION
The load-bearing multi-chain fix. The router hardcoded the Uniswap-V2 0.3% fee (`997/1000`) in `executePathStep`'s assembly and **ignored the validated `fees[]` array**, so it mispriced on every non-0.3% DEX — lossy on PancakeSwap (0.25%, BSC's own DEX) and a guaranteed `K`-revert on any higher-fee fork. This blocked multi-DEX / multi-chain use.

> Stacked on `feat/multichain-phase1` (#36). Retarget to `main` once the parents merge. This PR is a **behavior change** and is intentionally separate from the no-behavior-change Phase-1 config PR.

## Contract — `BofhContractV2.sol`
- `executePathStep` takes a per-hop `feeBps` and prices on a **10000 basis**: `amountInWithFee = amountIn*(10000-feeBps)`, `out = amountInWithFee*reserveOut / (reserveIn*10000 + amountInWithFee)`. **`feeBps=30` reproduces the legacy `997/1000` result to the wei**, so behavior at 0.3% is byte-identical (both numerator and denominator scale by exactly 10).
- The hop loop now passes `fees[i]`; added a defense-in-depth `feeBps <= MAX_FEE_BPS` guard in the private helper.
- `MAX_FEE_BPS` tightened from 10000 (100%) → **1000 (10%)**.

## Mock — `MockPair.sol`
- `FEE_DENOMINATOR` 1000 → 10000; default `swapFee` 3 → 30 (still 0.3%); added `setSwapFee()` so tests can emulate 0.25% / 0.5% pools. K-invariant check unchanged and overflow-safe.

## Tests
- Normalized every placeholder fee array (`[3000…]`/`[300…]`/`[3…]`) to **30** (= 0.3%, matching the MockPair default) so existing assertions hold against the now fee-aware router. **No assertions weakened/skipped** (verified by the backward-compat reviewer; per-file diffs are balanced 1:1).
- New `test/FeePortability.test.js`:
  - **(a)** 0.25% pool priced at `feeBps=25` → succeeds, realized output equals the fee-correct constant-product amount-out.
  - **(b)** 0.5% pool priced **correctly** at `feeBps=50` → **succeeds** — the discriminating case the legacy 0.3%-hardcoded router could *not* serve (it would `K`-revert); plus an under-priced (`feeBps=30`) case that reverts with `"K"`.
  - **(c)** fee sensitivity: 0.25% pool yields strictly more than 0.30% for identical reserves/amount.

## Verification
- `hardhat compile` (evm target london) ✅
- Full suite: **295 passing, 4 pending** ✅ (was 291; +4 fee-portability tests)
- Adversarially reviewed across **fee-math** (PASS — formula bit-identical at 0.3%, no assembly underflow), **backward-compat** (PASS — no cheating-to-green), and **test-adequacy** (review-driven fixes applied: made (b) discriminating, `revertedWith("K")`, EVM-clock deadlines).

## Out of scope (follow-ups)
- `getOptimalPathMetrics` is still fee-unaware (off-chain quote will diverge from execution) — Phase 2.
- DEX-adapter registry wiring (per-hop `dexIds[]`, cross-DEX routing) and fee-on-transfer output sizing — Phase 2.