### PR TITLE
feat(swap): Phase 2 — DEX-agnostic multi-DEX routing + fee-aware views + FoT-safe sizing

### DIFF
--- a/contracts/adapters/IDEXAdapter.sol
+++ b/contracts/adapters/IDEXAdapter.sol
@@ -5,6 +5,12 @@ pragma solidity >=0.8.10;
 /// @notice Interface for DEX adapter implementations supporting multiple protocols
 /// @dev Abstracts DEX-specific logic (Uniswap V2, PancakeSwap, SushiSwap, etc.)
 /// @custom:pattern Adapter Pattern - Provides uniform interface to different DEX implementations
+/// @custom:warning NOT used by BofhContractV2's swap hot path. The router does multi-DEX routing via
+/// @custom:warning the on-chain DexRegistry ({factory, feeBps} per dexId) and keeps its proven
+/// @custom:warning pre-fund -> IGenericPair.swap -> balanceOf-delta token-flow. Adapter executeSwap
+/// @custom:warning pulls via transferFrom(msg.sender) and reprices with a hardcoded fee, which would
+/// @custom:warning double-pull intermediate tokens and re-introduce the "K"-revert fee bug. These
+/// @custom:warning adapters remain quote/off-chain helpers only.
 interface IDEXAdapter {
     // ============================================
     // EVENTS

--- a/contracts/interfaces/IBofhContract.sol
+++ b/contracts/interfaces/IBofhContract.sol
@@ -149,6 +149,12 @@ interface IBofhContract {
         external
         returns (uint256[] memory outputs);
 
+    // NOTE: The multi-DEX entrypoints (executeSwapMultiDex, the 3-arg getOptimalPathMetrics overload,
+    // getOptimalPathMetricsMultiDex) and the registry admin (setDex/getDex) are declared directly on
+    // BofhContractV2/BofhContractBase, NOT here, so this interface stays minimal and pre-existing
+    // implementors (e.g. mocks) are not forced to implement them. They are fully exposed in the
+    // contract's own ABI for callers. Add them here in a later PR if a shared interface is needed.
+
     // ============================================
     // VIEW FUNCTIONS
     // ============================================

--- a/contracts/main/BofhContractBase.sol
+++ b/contracts/main/BofhContractBase.sol
@@ -6,14 +6,17 @@ import "../libs/MathLib.sol";
 import "../libs/PoolLib.sol";
 import "../interfaces/ISwapInterfaces.sol";
 import "../interfaces/IBofhContractBase.sol";
+import "./DexRegistry.sol";
 
 /// @title BofhContractBase - Abstract Base Contract with Security and Risk Management
 /// @author Bofh Team
 /// @notice Provides security features, risk parameters, and MEV protection for swap contracts
 /// @dev Abstract contract inherited by BofhContractV2, implements security primitives and modifiers
+/// @dev Inherits DexRegistry so it can expose the onlyOwner setDex wrapper while keeping the
+/// @dev registry storage/struct/resolver in a separate small contract (respects file size limits).
 /// @custom:security Implements reentrancy protection, access control, pause mechanism, and MEV protection
 /// @custom:risk Configurable risk parameters: maxTradeVolume, minPoolLiquidity, maxPriceImpact, sandwichProtection
-abstract contract BofhContractBase is IBofhContractBase {
+abstract contract BofhContractBase is IBofhContractBase, DexRegistry {
     using SecurityLib for SecurityLib.SecurityState;
     using PoolLib for PoolLib.PoolState;
 
@@ -236,6 +239,24 @@ abstract contract BofhContractBase is IBofhContractBase {
         require(pool != address(0), "Invalid pool");
         blacklistedPools[pool] = blacklisted;
         emit PoolBlacklisted(pool, blacklisted);
+    }
+
+    /// @notice Register or update a DEX for multi-DEX routing (owner-only)
+    /// @dev onlyOwner wrapper around DexRegistry._setDex. Keeps access control in one place
+    /// @dev and avoids inverting the inheritance hierarchy (registry sits below onlyOwner).
+    /// @param dexId Registry id (> 0; id 0 is reserved for the router's immutable factory)
+    /// @param factory_ Uniswap-V2-style factory for this DEX (must be non-zero)
+    /// @param feeBps Flat per-hop fee in basis points out of 10000 (<= MAX_FEE_BPS)
+    /// @param enabled Whether the DEX may be used immediately
+    /// @custom:security Reverts DexAlreadyReserved (id 0), InvalidDexFactory (zero factory),
+    /// @custom:security InvalidFee (feeBps > MAX_FEE_BPS). Emits DexRegistered.
+    function setDex(
+        uint16 dexId,
+        address factory_,
+        uint16 feeBps,
+        bool enabled
+    ) external onlyOwner {
+        _setDex(dexId, factory_, feeBps, enabled);
     }
 
     /// @notice Configure MEV protection parameters (Issue #9)

--- a/contracts/main/BofhContractV2.sol
+++ b/contracts/main/BofhContractV2.sol
@@ -21,8 +21,10 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @notice Uniswap V2-style factory address for pair lookups
     address private immutable factory;
 
-    /// @notice Maximum allowed fee in basis points (100% = 10000 bps)
-    uint256 private constant MAX_FEE_BPS = 10000;
+    /// @notice Maximum allowed per-hop fee in basis points out of 10000 (10% = 1000 bps)
+    /// @dev Tightened from 10000 (100%) to 1000 (10%): rejects absurd fees while still covering
+    /// @dev real-world DEX forks. Per-fee validation in _validateSwapInputs enforces this cap.
+    uint256 private constant MAX_FEE_BPS = 1000;
 
     /// @notice Internal state tracking for multi-step swap execution
     /// @dev Minimal state for tracking swap progress across multiple hops
@@ -66,7 +68,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @notice Validate all swap parameters before execution
     /// @dev Comprehensive validation: deadline, array lengths, amounts, addresses, path structure, fees
     /// @dev Validates: 1) Deadline not expired, 2) Arrays correct length, 3) Amounts > 0,
-    /// @dev 4) Addresses non-zero, 5) Path starts/ends with baseToken, 6) Fees ≤ 100%
+    /// @dev 4) Addresses non-zero, 5) Path starts/ends with baseToken, 6) Fees ≤ MAX_FEE_BPS (10%)
     /// @param path Token swap path (must start and end with baseToken)
     /// @param fees Fee array in basis points (length = path.length - 1)
     /// @param amountIn Input amount (must be > 0)
@@ -106,7 +108,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         address cachedBaseToken = baseToken;
         if (path[0] != cachedBaseToken || path[pathLength - 1] != cachedBaseToken) revert InvalidPath();
 
-        // 6. Fee validation (fees must be reasonable, max 100% = 10000 bps)
+        // 6. Fee validation (fees must be reasonable, max MAX_FEE_BPS = 1000 bps = 10%)
         for (uint256 i = 0; i < fees.length;) {
             if (fees[i] > MAX_FEE_BPS) revert InvalidFee();
             unchecked { ++i; }
@@ -182,7 +184,8 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             state = executePathStep(
                 state,
                 path[i],
-                path[i + 1]
+                path[i + 1],
+                fees[i]
             );
 
             unchecked {
@@ -365,14 +368,23 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @param state Current swap state (token, amount, impact)
     /// @param tokenIn Input token address for this step
     /// @param tokenOut Output token address for this step
+    /// @param feeBps Per-hop swap fee in basis points out of 10000 (e.g. 30 = 0.3%, 25 = 0.25%)
     /// @return Updated swap state with new currentAmount and cumulativeImpact
     /// @custom:security Validates pool liquidity and calculates price impact before swap
-    /// @custom:optimization Removed unused parameters (fee, stepIndex, pathLength) for gas savings
+    /// @custom:optimization Removed unused parameters (stepIndex, pathLength) for gas savings
+    /// @custom:fee Consumes the caller-supplied per-hop fee so the router prices correctly on
+    /// @custom:fee DEXes with non-0.3% fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks)
     function executePathStep(
         SwapState memory state,
         address tokenIn,
-        address tokenOut
+        address tokenOut,
+        uint256 feeBps
     ) private returns (SwapState memory) {
+        // Defense-in-depth: the assembly below computes (10000 - feeBps). Callers reach this
+        // private helper only via _validateSwapInputs (which enforces fees[i] <= MAX_FEE_BPS),
+        // but re-check here so the subtraction can never underflow if a future caller forgets.
+        if (feeBps > MAX_FEE_BPS) revert InvalidFee();
+
         // Get the pair address for these two tokens
         address pairAddress = _getPair(tokenIn, tokenOut);
 
@@ -397,7 +409,9 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         if (!PoolLib.validateSwap(pool, params)) revert InvalidSwapParameters();
 
         // Calculate expected output using constant product formula (x * y = k)
-        // amountOut = (amountIn * reserveOut * 997) / (reserveIn * 1000 + amountIn * 997)
+        // amountOut = (amountIn * reserveOut * (10000 - feeBps)) /
+        //             (reserveIn * 10000 + amountIn * (10000 - feeBps))
+        // feeBps is a 10000-basis per-hop fee (30 = 0.3%, reproducing the legacy 997/1000 result).
         // Phase 3 optimization: Assembly for maximum gas efficiency
         uint256 expectedOutput;
         assembly {
@@ -406,14 +420,17 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             let reserveOut := mload(add(pool, 0x20)) // pool.reserveOut (2nd field after reserveIn)
             let reserveIn := mload(pool) // pool.reserveIn (1st field)
 
-            // Calculate: amountInWithFee = amountIn * 997
-            let amountInWithFee := mul(amountIn, 997)
+            // Calculate: feeNum = 10000 - feeBps (feeBps=30 -> 9970, i.e. legacy 0.3%)
+            let feeNum := sub(10000, feeBps)
+
+            // Calculate: amountInWithFee = amountIn * feeNum
+            let amountInWithFee := mul(amountIn, feeNum)
 
             // Calculate: numerator = amountInWithFee * reserveOut
             let numerator := mul(amountInWithFee, reserveOut)
 
-            // Calculate: denominator = reserveIn * 1000 + amountInWithFee
-            let denominator := add(mul(reserveIn, 1000), amountInWithFee)
+            // Calculate: denominator = reserveIn * 10000 + amountInWithFee
+            let denominator := add(mul(reserveIn, 10000), amountInWithFee)
 
             // Calculate: expectedOutput = numerator / denominator
             expectedOutput := div(numerator, denominator)

--- a/contracts/main/BofhContractV2.sol
+++ b/contracts/main/BofhContractV2.sol
@@ -21,10 +21,18 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @notice Uniswap V2-style factory address for pair lookups
     address private immutable factory;
 
-    /// @notice Maximum allowed per-hop fee in basis points out of 10000 (10% = 1000 bps)
-    /// @dev Tightened from 10000 (100%) to 1000 (10%): rejects absurd fees while still covering
-    /// @dev real-world DEX forks. Per-fee validation in _validateSwapInputs enforces this cap.
-    uint256 private constant MAX_FEE_BPS = 1000;
+    /// @notice Default per-hop fee in basis points used for the reserved dexId 0 (immutable factory)
+    /// @dev 30 = 0.3%, reproducing the legacy 997/1000 result. The multi-DEX worker substitutes
+    /// @dev this only when a caller opts in via the type(uint256).max sentinel for that hop.
+    uint16 private constant DEFAULT_DEX_FEE_BPS = 30;
+
+    /// @notice Sentinel fee value: when fees[i] == this, substitute the resolved DEX's registry fee
+    /// @dev Lets callers say "use whatever this DEX charges" without knowing it, while keeping
+    /// @dev an explicit fees[i] caller-authoritative by default.
+    uint256 private constant USE_REGISTRY_FEE = type(uint256).max;
+
+    // MAX_FEE_BPS (= 1000) is inherited from DexRegistry so the registry's feeBps validation
+    // and this router's _validateSwapInputs reference one single definition.
 
     /// @notice Internal state tracking for multi-step swap execution
     /// @dev Minimal state for tracking swap progress across multiple hops
@@ -36,6 +44,20 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         address currentToken;
         uint256 currentAmount;
         uint256 cumulativeImpact;
+    }
+
+    /// @notice In-memory simulated reserve record for a pair, used ONLY by the fee-aware views
+    /// @dev Lets getOptimalPathMetrics(fees) reflect intra-path reserve changes when a path revisits
+    /// @dev the same pool (e.g. BASE->A->BASE), so the view matches realized execution to the wei.
+    /// @dev Reserves are stored CANONICALLY in token0/token1 orientation (not per-hop tokenIn) so any
+    /// @dev later hop reads them correctly regardless of direction.
+    /// @custom:field pair Pair contract address (zero = empty slot)
+    /// @custom:field reserve0 Simulated reserve of token0
+    /// @custom:field reserve1 Simulated reserve of token1
+    struct SimReserve {
+        address pair;
+        uint256 reserve0;
+        uint256 reserve1;
     }
 
     // Custom errors inherited from IBofhContract interface
@@ -179,13 +201,16 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             _safeTransferFrom(cachedBaseToken, msg.sender, address(this), amountIn);
         }
 
-        // Execute swaps along the path
+        // Execute swaps along the path (legacy single-DEX: every hop uses the immutable factory).
+        // Pass the immutable `factory` directly (no local) to keep the stack footprint unchanged.
         for (uint256 i = 0; i < lastIndex;) {
             state = executePathStep(
                 state,
                 path[i],
                 path[i + 1],
-                fees[i]
+                fees[i],
+                factory,
+                false // legacy path: no FoT entry/per-hop resizing (byte-identical behavior)
             );
 
             unchecked {
@@ -363,6 +388,167 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         return outputs;
     }
 
+    /// @notice Execute a single swap whose hops may route through DIFFERENT registered DEXes
+    /// @dev ADDITIVE multi-DEX entrypoint. Same proven token-flow as executeSwap (pre-fund ->
+    /// @dev IGenericPair.swap -> balanceOf delta); the ONLY difference is each hop resolves its
+    /// @dev pair from a per-hop factory selected by dexIds[i]. dexId 0 = the immutable factory.
+    /// @dev Protected by nonReentrant, whenNotPaused, antiMEV (identical to executeSwap).
+    /// @param path Token swap path (must start and end with baseToken)
+    /// @param fees Per-hop fee array in basis points; fees[i]==type(uint256).max opts into the
+    /// @param fees registry feeBps for that hop, otherwise the explicit value is authoritative
+    /// @param dexIds Per-hop DEX selector (length = path.length - 1). dexId 0 = immutable factory
+    /// @param amountIn Input amount in baseToken
+    /// @param minAmountOut Minimum acceptable output (slippage protection)
+    /// @param deadline Unix timestamp after which the transaction reverts
+    /// @return The actual output amount from the swap
+    function executeSwapMultiDex(
+        address[] calldata path,
+        uint256[] calldata fees,
+        uint16[] calldata dexIds,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external nonReentrant whenNotPaused antiMEV returns (uint256) {
+        return _executeSwapMultiDex(path, fees, dexIds, amountIn, minAmountOut, deadline);
+    }
+
+    /// @notice Multi-DEX swap worker (clone of _executeSwapToRecipient with per-hop factory resolution)
+    /// @dev Adds: (1) dexIds length check, (2) per-hop (factory,fee) resolution via _resolveDex,
+    /// @dev (3) FoT-aware entry sizing (seed currentAmount from the realized baseToken delta).
+    /// @dev Output-side FoT is already correct everywhere because per-hop output is balanceOf-delta based.
+    function _executeSwapMultiDex(
+        address[] calldata path,
+        uint256[] calldata fees,
+        uint16[] calldata dexIds,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) internal returns (uint256) {
+        // Reuse the full input validation (deadline, path structure, amounts, fees <= MAX_FEE_BPS).
+        // Note: the registry-fee sentinel (type(uint256).max) is intentionally exempt from the
+        // fees[i] <= MAX_FEE_BPS check below by validating the substituted fee per hop instead.
+        uint256 pathLength = _validateSwapInputsMultiDex(path, fees, amountIn, minAmountOut, deadline);
+
+        // dexIds must parallel the hops
+        if (dexIds.length != pathLength - 1) revert InvalidArrayLength();
+
+        SwapState memory state;
+        {
+            address cachedBaseToken = baseToken;
+
+            // FoT-aware entry sizing: size the first hop on the RECEIVED baseToken, not the
+            // nominal amountIn. For non-FoT tokens received == amountIn (byte-identical behavior).
+            uint256 balBefore = IBEP20(cachedBaseToken).balanceOf(address(this));
+            _safeTransferFrom(cachedBaseToken, msg.sender, address(this), amountIn);
+            uint256 received = IBEP20(cachedBaseToken).balanceOf(address(this)) - balBefore;
+
+            state = SwapState({
+                currentToken: cachedBaseToken,
+                currentAmount: received,
+                cumulativeImpact: 0
+            });
+        }
+
+        // Execute swaps in a sub-call so the three calldata arrays do not co-exist with the
+        // loop locals on the stack (avoids "stack too deep").
+        state = _runMultiDexHops(state, path, dexIds, fees);
+
+        // Validate final output
+        if (state.currentAmount < minAmountOut) revert InsufficientOutput();
+
+        // Calculate total price impact and validate (uses nominal amountIn, matching legacy path)
+        uint256 priceImpact;
+        unchecked {
+            priceImpact = (state.cumulativeImpact * PRECISION) / amountIn;
+        }
+        if (priceImpact > maxPriceImpact) revert ExcessiveSlippage();
+
+        // Transfer profit to caller
+        _safeTransfer(baseToken, msg.sender, state.currentAmount);
+
+        emit SwapExecuted(
+            msg.sender,
+            pathLength,
+            amountIn,
+            state.currentAmount,
+            priceImpact
+        );
+
+        return state.currentAmount;
+    }
+
+    /// @notice Execute each hop of a multi-DEX swap, resolving the factory + fee per hop
+    /// @dev Extracted from _executeSwapMultiDex to reduce stack depth (the three calldata arrays
+    /// @dev no longer co-exist with the outer scalars/locals). Token-flow is identical to the
+    /// @dev legacy loop: pre-fund -> IGenericPair.swap -> balanceOf delta, only the factory varies.
+    /// @param state Current swap state (seeded with the FoT-aware received amount)
+    /// @param path Token path
+    /// @param dexIds Per-hop DEX selector (0 = immutable factory)
+    /// @param fees Per-hop caller fees (sentinel => registry fee)
+    /// @return Updated swap state after all hops
+    function _runMultiDexHops(
+        SwapState memory state,
+        address[] calldata path,
+        uint16[] calldata dexIds,
+        uint256[] calldata fees
+    ) private returns (SwapState memory) {
+        uint256 hops = dexIds.length;
+        for (uint256 i = 0; i < hops;) {
+            (address f, uint256 hopFee) = _resolveHopFactoryAndFee(dexIds[i], fees[i]);
+            state = executePathStep(
+                state,
+                path[i],
+                path[i + 1],
+                hopFee,
+                f,
+                true // multi-DEX path: FoT-safe per-hop output sizing
+            );
+            unchecked { ++i; }
+        }
+        return state;
+    }
+
+    /// @notice Validate multi-DEX swap inputs, allowing the registry-fee sentinel per hop
+    /// @dev Identical to _validateSwapInputs except a fees[i] == type(uint256).max sentinel is
+    /// @dev permitted (it means "use the registry's fee"); a concrete fee is still capped at MAX_FEE_BPS.
+    function _validateSwapInputsMultiDex(
+        address[] calldata path,
+        uint256[] calldata fees,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) private view returns (uint256 pathLength) {
+        // 1. Deadline validation
+        if (deadline == 0) revert InvalidAmount();
+        if (block.timestamp > deadline) revert DeadlineExpired();
+
+        // 2. Array length validation
+        pathLength = path.length;
+        if (pathLength == 0) revert InvalidArrayLength();
+        if (pathLength < 2 || pathLength > MAX_PATH_LENGTH) revert InvalidPath();
+        if (pathLength != fees.length + 1) revert InvalidArrayLength();
+
+        // 3. Amount validation
+        if (amountIn == 0) revert InvalidAmount();
+        if (minAmountOut == 0) revert InvalidAmount();
+
+        // 4. Path address validation
+        for (uint256 i = 0; i < pathLength;) {
+            if (path[i] == address(0)) revert InvalidAddress();
+            unchecked { ++i; }
+        }
+
+        // 5. Path structure validation (cache baseToken to avoid double SLOAD)
+        address cachedBaseToken = baseToken;
+        if (path[0] != cachedBaseToken || path[pathLength - 1] != cachedBaseToken) revert InvalidPath();
+
+        // 6. Fee validation: concrete fees capped at MAX_FEE_BPS; the registry-fee sentinel is allowed
+        for (uint256 i = 0; i < fees.length;) {
+            if (fees[i] != USE_REGISTRY_FEE && fees[i] > MAX_FEE_BPS) revert InvalidFee();
+            unchecked { ++i; }
+        }
+    }
+
     /// @notice Execute a single step in a multi-hop swap path
     /// @dev Executes swap through pair, updates swap state with new amount and cumulative price impact
     /// @param state Current swap state (token, amount, impact)
@@ -374,19 +560,29 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
     /// @custom:optimization Removed unused parameters (stepIndex, pathLength) for gas savings
     /// @custom:fee Consumes the caller-supplied per-hop fee so the router prices correctly on
     /// @custom:fee DEXes with non-0.3% fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks)
+    /// @param pairFactory Factory to resolve the pair for this hop. The legacy single-DEX path
+    /// @param pairFactory passes the immutable `factory` (so behavior is byte-identical); the
+    /// @param pairFactory multi-DEX worker passes the per-hop factory resolved from the registry.
+    /// @param fotSafe When false (legacy path) the proven assembly pricing + pre-fund order is used
+    /// @param fotSafe verbatim. When true (multi-DEX path) the output is sized on the amount the PAIR
+    /// @param fotSafe actually receives (measured via balanceOf delta), so fee-on-transfer tokens at
+    /// @param fotSafe ANY hop price correctly and never trip the pool's x*y=k ("K") check. For non-FoT
+    /// @param fotSafe tokens the pair-received amount equals the amount sent, so results are identical.
     function executePathStep(
         SwapState memory state,
         address tokenIn,
         address tokenOut,
-        uint256 feeBps
+        uint256 feeBps,
+        address pairFactory,
+        bool fotSafe
     ) private returns (SwapState memory) {
-        // Defense-in-depth: the assembly below computes (10000 - feeBps). Callers reach this
-        // private helper only via _validateSwapInputs (which enforces fees[i] <= MAX_FEE_BPS),
-        // but re-check here so the subtraction can never underflow if a future caller forgets.
+        // Defense-in-depth: the pricing computes (10000 - feeBps). Callers reach this private helper
+        // only via validated entrypoints (fees[i] <= MAX_FEE_BPS), but re-check so the subtraction
+        // can never underflow if a future caller forgets.
         if (feeBps > MAX_FEE_BPS) revert InvalidFee();
 
-        // Get the pair address for these two tokens
-        address pairAddress = _getPair(tokenIn, tokenOut);
+        // Get the pair address for these two tokens from the supplied factory (DEX-specific)
+        address pairAddress = _getPairFrom(pairFactory, tokenIn, tokenOut);
 
         // Analyze pool state using the pair address
         PoolLib.PoolState memory pool = PoolLib.analyzePool(
@@ -408,54 +604,61 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         // Validate pool state
         if (!PoolLib.validateSwap(pool, params)) revert InvalidSwapParameters();
 
-        // Calculate expected output using constant product formula (x * y = k)
-        // amountOut = (amountIn * reserveOut * (10000 - feeBps)) /
-        //             (reserveIn * 10000 + amountIn * (10000 - feeBps))
-        // feeBps is a 10000-basis per-hop fee (30 = 0.3%, reproducing the legacy 997/1000 result).
-        // Phase 3 optimization: Assembly for maximum gas efficiency
-        uint256 expectedOutput;
-        assembly {
-            // Load values from memory
-            let amountIn := mload(add(state, 0x20)) // state.currentAmount
-            let reserveOut := mload(add(pool, 0x20)) // pool.reserveOut (2nd field after reserveIn)
-            let reserveIn := mload(pool) // pool.reserveIn (1st field)
-
-            // Calculate: feeNum = 10000 - feeBps (feeBps=30 -> 9970, i.e. legacy 0.3%)
-            let feeNum := sub(10000, feeBps)
-
-            // Calculate: amountInWithFee = amountIn * feeNum
-            let amountInWithFee := mul(amountIn, feeNum)
-
-            // Calculate: numerator = amountInWithFee * reserveOut
-            let numerator := mul(amountInWithFee, reserveOut)
-
-            // Calculate: denominator = reserveIn * 10000 + amountInWithFee
-            let denominator := add(mul(reserveIn, 10000), amountInWithFee)
-
-            // Calculate: expectedOutput = numerator / denominator
-            expectedOutput := div(numerator, denominator)
-        }
-
         // Add price impact (keep in Solidity for struct access simplicity)
         unchecked {
             state.cumulativeImpact += pool.priceImpact;
         }
 
-        // Transfer tokens to the pair contract (Uniswap V2 pattern)
-        // Phase 3 optimization: Low-level call for gas efficiency
-        _safeTransfer(tokenIn, pairAddress, state.currentAmount);
+        if (fotSafe) {
+            // FoT-safe: transfer first, size output on the amount the PAIR actually received.
+            // Works for fee-on-transfer tokens at any hop; for normal tokens received == sent.
+            uint256 pairInBefore = IBEP20(tokenIn).balanceOf(pairAddress);
+            _safeTransfer(tokenIn, pairAddress, state.currentAmount);
+            uint256 pairReceived = IBEP20(tokenIn).balanceOf(pairAddress) - pairInBefore;
 
-        {
+            // Same CPMM-with-fee formula/operation-order as the legacy assembly below.
+            uint256 amountInWithFee = pairReceived * (10000 - feeBps);
+            uint256 expectedOutput =
+                (amountInWithFee * pool.reserveOut) / (pool.reserveIn * 10000 + amountInWithFee);
+
             uint256 balanceBefore = IBEP20(tokenOut).balanceOf(address(this));
-
-            // Execute swap on the pair contract
             IGenericPair(pairAddress).swap(
                 pool.sellingToken0 ? 0 : expectedOutput,
                 pool.sellingToken0 ? expectedOutput : 0,
                 address(this),
                 new bytes(0)
             );
+            state.currentAmount = IBEP20(tokenOut).balanceOf(address(this)) - balanceBefore;
+            state.currentToken = tokenOut;
+            return state;
+        }
 
+        // Legacy path (byte-identical): assembly pricing on state.currentAmount, then pre-fund + swap.
+        // amountOut = (amountIn * reserveOut * (10000 - feeBps)) /
+        //             (reserveIn * 10000 + amountIn * (10000 - feeBps))
+        uint256 legacyExpectedOutput;
+        assembly {
+            let amountIn := mload(add(state, 0x20)) // state.currentAmount
+            let reserveOut := mload(add(pool, 0x20)) // pool.reserveOut
+            let reserveIn := mload(pool) // pool.reserveIn
+            let feeNum := sub(10000, feeBps)
+            let amountInWithFee := mul(amountIn, feeNum)
+            let numerator := mul(amountInWithFee, reserveOut)
+            let denominator := add(mul(reserveIn, 10000), amountInWithFee)
+            legacyExpectedOutput := div(numerator, denominator)
+        }
+
+        // Transfer tokens to the pair contract (Uniswap V2 pattern)
+        _safeTransfer(tokenIn, pairAddress, state.currentAmount);
+
+        {
+            uint256 balanceBefore = IBEP20(tokenOut).balanceOf(address(this));
+            IGenericPair(pairAddress).swap(
+                pool.sellingToken0 ? 0 : legacyExpectedOutput,
+                pool.sellingToken0 ? legacyExpectedOutput : 0,
+                address(this),
+                new bytes(0)
+            );
             state.currentAmount = IBEP20(tokenOut).balanceOf(address(this)) - balanceBefore;
         }
         state.currentToken = tokenOut;
@@ -511,14 +714,308 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         return (expectedOutput, priceImpact, optimalityScore);
     }
 
-    /// @notice Get pair address for two tokens from factory
-    /// @dev Helper function to resolve pair address from token addresses
+    /// @notice Fee-aware metrics: off-chain mirror of executeSwap that EXACTLY matches realized output
+    /// @dev ADDITIVE, DISTINCTLY NAMED (not an overload of getOptimalPathMetrics) so ABI consumers
+    /// @dev never face an ambiguous-by-arity selector. Uses the identical constant-product-with-fee
+    /// @dev formula as executePathStep (and the same operation order), chaining reserves hop-by-hop so
+    /// @dev the returned expectedOutput equals the realized round-trip output of executeSwap to the wei
+    /// @dev for standard (non-fee-on-transfer) ERC20s.
+    /// @param path Array of token addresses for the swap path (resolved against the immutable factory)
+    /// @param amounts Array whose amounts[0] is the initial input
+    /// @param fees Per-hop fee array in basis points (length = path.length - 1, each <= MAX_FEE_BPS)
+    /// @return expectedOutput Final expected output after all hops
+    /// @return priceImpact Cumulative price impact across the path (scaled by PRECISION)
+    /// @return optimalityScore Ratio of output to input (scaled by PRECISION, >1e6 = profitable)
+    function getOptimalPathMetricsWithFees(
+        address[] calldata path,
+        uint256[] calldata amounts,
+        uint256[] calldata fees
+    ) external view returns (
+        uint256 expectedOutput,
+        uint256 priceImpact,
+        uint256 optimalityScore
+    ) {
+        if (path.length < 2 || path.length > MAX_PATH_LENGTH) revert InvalidPath();
+        if (fees.length != path.length - 1) revert InvalidArrayLength();
+
+        // Simulate the full path (tracking per-pair reserve changes) so the result equals exec.
+        (expectedOutput, priceImpact) = _simulatePath(path, fees, amounts[0]);
+
+        unchecked {
+            optimalityScore = (expectedOutput * PRECISION) / amounts[0];
+        }
+    }
+
+    /// @notice Fee- and DEX-aware metrics: off-chain mirror of executeSwapMultiDex
+    /// @dev ADDITIVE. Resolves each hop's factory (and optional fee) via _resolveDex, then prices
+    /// @dev with the same CPMM-with-fee formula as executePathStep so view == exec for multi-DEX paths
+    /// @dev of standard (non-fee-on-transfer) ERC20s (FoT/rebasing tokens are not modelled by the view).
+    /// @param path Array of token addresses for the swap path
+    /// @param amounts Array whose amounts[0] is the initial input
+    /// @param dexIds Per-hop DEX selector (length = path.length - 1; dexId 0 = immutable factory)
+    /// @param fees Per-hop fee array; fees[i]==type(uint256).max uses the resolved DEX's registry fee
+    /// @return expectedOutput Final expected output after all hops
+    /// @return priceImpact Cumulative price impact across the path (scaled by PRECISION)
+    /// @return optimalityScore Ratio of output to input (scaled by PRECISION, >1e6 = profitable)
+    function getOptimalPathMetricsMultiDex(
+        address[] calldata path,
+        uint256[] calldata amounts,
+        uint16[] calldata dexIds,
+        uint256[] calldata fees
+    ) external view returns (
+        uint256 expectedOutput,
+        uint256 priceImpact,
+        uint256 optimalityScore
+    ) {
+        if (path.length < 2 || path.length > MAX_PATH_LENGTH) revert InvalidPath();
+        if (fees.length != path.length - 1) revert InvalidArrayLength();
+        if (dexIds.length != path.length - 1) revert InvalidArrayLength();
+
+        // Resolve per-hop factories + effective fees into memory arrays, then simulate (sub-calls
+        // keep the four calldata arrays off the stack during the loop -> avoids "stack too deep").
+        (address[] memory factories, uint256[] memory hopFees) = _resolveHops(dexIds, fees);
+        (expectedOutput, priceImpact) = _simulatePathMultiDex(path, factories, hopFees, amounts[0]);
+
+        unchecked {
+            optimalityScore = (expectedOutput * PRECISION) / amounts[0];
+        }
+    }
+
+    /// @notice Resolve per-hop (factory, fee) for every hop from dexIds + caller fees
+    /// @dev Applies the registry-fee sentinel and caps each effective fee at MAX_FEE_BPS.
+    /// @param dexIds Per-hop DEX selector
+    /// @param fees Per-hop caller fees (sentinel => registry fee)
+    /// @return factories Resolved per-hop factory addresses
+    /// @return hopFees Effective per-hop fees in basis points
+    function _resolveHops(
+        uint16[] calldata dexIds,
+        uint256[] calldata fees
+    ) private view returns (address[] memory factories, uint256[] memory hopFees) {
+        uint256 hops = dexIds.length;
+        factories = new address[](hops);
+        hopFees = new uint256[](hops);
+        for (uint256 i = 0; i < hops;) {
+            (address f, uint16 regFee) = _resolveDex(dexIds[i]);
+            uint256 hopFee = fees[i] == USE_REGISTRY_FEE ? uint256(regFee) : fees[i];
+            if (hopFee > MAX_FEE_BPS) revert InvalidFee();
+            factories[i] = f;
+            hopFees[i] = hopFee;
+            unchecked { ++i; }
+        }
+    }
+
+    /// @notice Resolve a hop's (factory, fee) from a dexId + caller fee, applying the registry sentinel
+    /// @dev Used by the multi-DEX EXECUTION worker. Caps the resolved fee at MAX_FEE_BPS.
+    /// @param dexId Per-hop DEX selector (0 = immutable factory)
+    /// @param callerFee Caller fee for this hop (type(uint256).max => use the resolved DEX's fee)
+    /// @return f Resolved factory address
+    /// @return hopFee Effective per-hop fee in basis points (<= MAX_FEE_BPS)
+    function _resolveHopFactoryAndFee(uint16 dexId, uint256 callerFee) private view returns (address f, uint256 hopFee) {
+        uint16 regFee;
+        (f, regFee) = _resolveDex(dexId);
+        hopFee = callerFee == USE_REGISTRY_FEE ? uint256(regFee) : callerFee;
+        if (hopFee > MAX_FEE_BPS) revert InvalidFee();
+    }
+
+    /// @notice Simulate a single-DEX path (all hops via the immutable factory) with reserve tracking
+    /// @dev Mirrors realized execution EXACTLY: prices each hop with the CPMM-with-fee formula and
+    /// @dev updates the pool's simulated reserves, so revisited pools (e.g. BASE->A->BASE) match exec.
+    /// @param path Token path
+    /// @param fees Per-hop fees in basis points (each validated <= MAX_FEE_BPS here)
+    /// @param amountIn Initial input amount
+    /// @return expectedOutput Final output after all hops
+    /// @return cumulativeImpact Accumulated price impact across hops
+    function _simulatePath(
+        address[] calldata path,
+        uint256[] calldata fees,
+        uint256 amountIn
+    ) private view returns (uint256 expectedOutput, uint256 cumulativeImpact) {
+        uint256 hops = path.length - 1;
+        SimReserve[] memory sims = new SimReserve[](hops);
+        uint256 simCount;
+        expectedOutput = amountIn;
+
+        for (uint256 i = 0; i < hops;) {
+            if (fees[i] > MAX_FEE_BPS) revert InvalidFee();
+            (expectedOutput, cumulativeImpact, simCount) = _simHop(
+                _getPairFrom(factory, path[i], path[i + 1]),
+                path[i],
+                expectedOutput,
+                fees[i],
+                cumulativeImpact,
+                sims,
+                simCount
+            );
+            unchecked { ++i; }
+        }
+    }
+
+    /// @notice Simulate a multi-DEX path (per-hop factories) with reserve tracking
+    /// @dev Same reserve-tracking simulation as _simulatePath but each hop uses factories[i].
+    /// @param path Token path
+    /// @param factories Per-hop resolved factory addresses
+    /// @param hopFees Per-hop effective fees in basis points
+    /// @param amountIn Initial input amount
+    /// @return expectedOutput Final output after all hops
+    /// @return cumulativeImpact Accumulated price impact across hops
+    function _simulatePathMultiDex(
+        address[] calldata path,
+        address[] memory factories,
+        uint256[] memory hopFees,
+        uint256 amountIn
+    ) private view returns (uint256 expectedOutput, uint256 cumulativeImpact) {
+        uint256 hops = path.length - 1;
+        SimReserve[] memory sims = new SimReserve[](hops);
+        uint256 simCount;
+        expectedOutput = amountIn;
+
+        for (uint256 i = 0; i < hops;) {
+            (expectedOutput, cumulativeImpact, simCount) = _simHop(
+                _getPairFrom(factories[i], path[i], path[i + 1]),
+                path[i],
+                expectedOutput,
+                hopFees[i],
+                cumulativeImpact,
+                sims,
+                simCount
+            );
+            unchecked { ++i; }
+        }
+    }
+
+    /// @notice Price one simulated hop, tracking the pool's reserves so revisits match exec
+    /// @dev On first encounter of a pair, seeds simulated reserves from live reserves (oriented to
+    /// @dev this hop's tokenIn). Computes amountOut with the same operation order as executePathStep,
+    /// @dev accumulates price impact on the pre-hop reserves, then updates the simulated reserves.
+    /// @param pairAddress Resolved pair for this hop
+    /// @param tokenIn Input token for this hop
+    /// @param amountIn Input amount for this hop
+    /// @param feeBps Per-hop fee in basis points
+    /// @param cumulativeImpact Running cumulative price impact
+    /// @param sims Memory array of tracked pair reserve states
+    /// @param simCount Number of populated entries in sims
+    /// @return amountOut Output amount for this hop
+    /// @return newCumulativeImpact Updated cumulative price impact
+    /// @return newSimCount Updated number of populated sims entries
+    function _simHop(
+        address pairAddress,
+        address tokenIn,
+        uint256 amountIn,
+        uint256 feeBps,
+        uint256 cumulativeImpact,
+        SimReserve[] memory sims,
+        uint256 simCount
+    ) private view returns (uint256 amountOut, uint256 newCumulativeImpact, uint256 newSimCount) {
+        // Locate (or seed) this pair's simulated reserves in canonical token0/token1 orientation.
+        (uint256 idx, bool found) = _findSim(pairAddress, sims, simCount);
+        newSimCount = simCount;
+        if (!found) {
+            // First encounter: read live reserves canonically (token0/token1).
+            (uint256 r0, uint256 r1) = _liveReserves(pairAddress);
+            idx = simCount;
+            sims[idx] = SimReserve({pair: pairAddress, reserve0: r0, reserve1: r1});
+            unchecked { newSimCount = simCount + 1; }
+        }
+
+        // Orient to this hop's input token.
+        bool inIsToken0 = (tokenIn == IGenericPair(pairAddress).token0());
+        uint256 reserveIn = inIsToken0 ? sims[idx].reserve0 : sims[idx].reserve1;
+        uint256 reserveOut = inIsToken0 ? sims[idx].reserve1 : sims[idx].reserve0;
+
+        // Price impact on pre-hop reserves (matches PoolLib._calculatePriceImpactInline math).
+        unchecked {
+            newCumulativeImpact = cumulativeImpact + _priceImpact(amountIn, reserveIn, reserveOut);
+        }
+
+        // Same formula/operation-order as executePathStep's assembly so view == realized exec.
+        uint256 amountInWithFee = amountIn * (10000 - feeBps);
+        amountOut = (amountInWithFee * reserveOut) / (reserveIn * 10000 + amountInWithFee);
+
+        // Update simulated reserves (canonical orientation) for any later revisit on the path.
+        if (inIsToken0) {
+            sims[idx].reserve0 = reserveIn + amountIn;
+            sims[idx].reserve1 = reserveOut - amountOut;
+        } else {
+            sims[idx].reserve1 = reserveIn + amountIn;
+            sims[idx].reserve0 = reserveOut - amountOut;
+        }
+    }
+
+    /// @notice Find a pair's index in the tracked sims array
+    /// @param pairAddress Pair to look up
+    /// @param sims Tracked pair states
+    /// @param simCount Populated entries in sims
+    /// @return idx Index of the pair (valid only when found)
+    /// @return found True if the pair is already tracked
+    function _findSim(
+        address pairAddress,
+        SimReserve[] memory sims,
+        uint256 simCount
+    ) private pure returns (uint256 idx, bool found) {
+        for (uint256 j = 0; j < simCount;) {
+            if (sims[j].pair == pairAddress) return (j, true);
+            unchecked { ++j; }
+        }
+        return (0, false);
+    }
+
+    /// @notice Read a pair's live reserves in canonical token0/token1 orientation
+    /// @param pairAddress Pair to read
+    /// @return reserve0 Reserve of token0
+    /// @return reserve1 Reserve of token1
+    function _liveReserves(address pairAddress) private view returns (uint256 reserve0, uint256 reserve1) {
+        (reserve0, reserve1, ) = IGenericPair(pairAddress).getReserves();
+    }
+
+    /// @notice Price impact for a hop, matching PoolLib._calculatePriceImpactInline exactly
+    /// @param amountIn Input amount
+    /// @param reserveIn Input token reserve
+    /// @param reserveOut Output token reserve
+    /// @return Price impact scaled by PRECISION
+    function _priceImpact(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) private pure returns (uint256) {
+        if (amountIn == 0) return 0;
+        uint256 newReserveIn = reserveIn + amountIn;
+        uint256 newReserveOut = (reserveIn * reserveOut) / newReserveIn;
+        uint256 oldPrice = (reserveOut * PRECISION) / reserveIn;
+        uint256 newPrice = (newReserveOut * PRECISION) / newReserveIn;
+        if (newPrice >= oldPrice) return 0;
+        return ((oldPrice - newPrice) * PRECISION) / oldPrice;
+    }
+
+    /// @notice Get pair address for two tokens from the contract's immutable factory
+    /// @dev Thin wrapper over _getPairFrom for legacy callers (getOptimalPathMetrics). Byte-identical
+    /// @dev to the previous behavior: resolves against `factory` and reverts PairDoesNotExist on zero.
     /// @param tokenA First token address
     /// @param tokenB Second token address
     /// @return pair The pair contract address
     function _getPair(address tokenA, address tokenB) internal view returns (address pair) {
-        pair = IFactory(factory).getPair(tokenA, tokenB);
+        return _getPairFrom(factory, tokenA, tokenB);
+    }
+
+    /// @notice Get pair address for two tokens from an arbitrary V2-style factory
+    /// @dev Enables per-hop multi-DEX routing: the same token pair resolves to different pair
+    /// @dev addresses on different DEX factories. Reverts PairDoesNotExist if the factory has no pair.
+    /// @param pairFactory Uniswap-V2-style factory to query
+    /// @param tokenA First token address
+    /// @param tokenB Second token address
+    /// @return pair The pair contract address
+    function _getPairFrom(address pairFactory, address tokenA, address tokenB) internal view returns (address pair) {
+        pair = IFactory(pairFactory).getPair(tokenA, tokenB);
         if (pair == address(0)) revert PairDoesNotExist();
+    }
+
+    /// @notice Resolve a dexId to its (factory, feeBps) — overrides DexRegistry where `factory` is visible
+    /// @dev dexId 0 is reserved for the immutable factory and needs ZERO registry writes (the legacy
+    /// @dev single-DEX deployment behaves exactly as today). dexId > 0 reads the registry mapping and
+    /// @dev reverts DexNotRegistered if the factory is unset or the DEX is disabled.
+    /// @param dexId Registry id to resolve
+    /// @return f Factory address for the resolved DEX
+    /// @return feeBps Flat per-hop fee for the resolved DEX
+    function _resolveDex(uint16 dexId) internal view override returns (address f, uint16 feeBps) {
+        if (dexId == 0) return (factory, DEFAULT_DEX_FEE_BPS);
+        DexInfo storage d = _dexRegistry[dexId];
+        if (d.factory == address(0) || !d.enabled) revert DexNotRegistered(dexId);
+        return (d.factory, d.feeBps);
     }
 
     /// @notice Get the base token address used for swaps

--- a/contracts/main/DexRegistry.sol
+++ b/contracts/main/DexRegistry.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import "../interfaces/IBofhContract.sol";
+
+/// @title DexRegistry - On-chain registry of V2-fork DEXes for multi-DEX routing
+/// @author Bofh Team
+/// @notice Holds a per-DEX record of {factory, feeBps, enabled} so a single router
+/// @notice deployment can route different hops through different Uniswap-V2-style
+/// @notice forks (Pancake 0.25%, Uniswap/Quickswap/Sushi 0.3%, higher-fee forks).
+/// @dev All target DEXes share the identical IGenericPair.swap ABI and x*y=k CPMM math,
+/// @dev differing ONLY in a flat per-hop fee. The single thing that makes a hop route
+/// @dev through Pancake vs Sushi is WHICH pair address swap() is called on, and that
+/// @dev address is fully determined by (factory, tokenIn, tokenOut). So a {factory, feeBps}
+/// @dev record per DEX is sufficient — no per-DEX code, no adapter delegation.
+/// @dev This abstract contract holds the registry storage + admin surface so the already
+/// @dev large BofhContractV2 does not grow it (respects the 500-line soft limit).
+/// @custom:security _setDex is internal; the onlyOwner wrapper lives in BofhContractBase.
+abstract contract DexRegistry {
+    /// @notice Maximum allowed per-hop fee in basis points out of 10000 (10% = 1000 bps)
+    /// @dev Relocated here from BofhContractV2 so both the registry feeBps validation and
+    /// @dev the router's _validateSwapInputs reference one single definition.
+    uint256 internal constant MAX_FEE_BPS = 1000;
+
+    /// @notice Per-DEX record. Packs into a single storage slot (160 + 16 + 8 = 184 bits).
+    /// @custom:field factory Uniswap-V2-style factory address used for getPair lookups
+    /// @custom:field feeBps Flat per-hop fee in basis points out of 10000 (25 = 0.25%, 30 = 0.3%)
+    /// @custom:field enabled Whether this DEX may be used to resolve a hop
+    struct DexInfo {
+        address factory;
+        uint16 feeBps;
+        bool enabled;
+    }
+
+    /// @notice dexId => DexInfo. dexId 0 is RESERVED for the router's immutable factory
+    /// @notice and is NOT stored here (resolved specially by the router's _resolveDex override).
+    mapping(uint16 => DexInfo) internal _dexRegistry;
+
+    /// @notice Emitted when a DEX is registered/updated via setDex
+    /// @param dexId Registry id (must be > 0)
+    /// @param factory Factory address for this DEX
+    /// @param feeBps Flat per-hop fee in basis points
+    /// @param enabled Whether the DEX is enabled
+    event DexRegistered(uint16 indexed dexId, address indexed factory, uint16 feeBps, bool enabled);
+
+    /// @notice Thrown when resolving a dexId that is not registered or is disabled
+    error DexNotRegistered(uint16 dexId);
+
+    /// @notice Thrown when attempting to register dexId 0 (reserved for the immutable factory)
+    error DexAlreadyReserved();
+
+    /// @notice Thrown when registering a DEX with a zero factory address
+    error InvalidDexFactory();
+
+    // Fee-cap violations revert with IBofhContract.InvalidFee (same selector the router uses)
+    // so callers/tests see a single InvalidFee error across the codebase. Referenced as a
+    // qualified error below; IBofhContract is imported but NOT inherited (no interface coupling).
+
+    /// @notice Register or update a DEX record (internal; gated by onlyOwner wrapper upstream)
+    /// @dev Reverts DexAlreadyReserved if dexId==0, InvalidDexFactory if factory_==0,
+    /// @dev InvalidFee if feeBps>MAX_FEE_BPS. Writes the packed struct and emits DexRegistered.
+    /// @param dexId Registry id (must be > 0; 0 is the reserved immutable factory)
+    /// @param factory_ Uniswap-V2-style factory for this DEX (must be non-zero)
+    /// @param feeBps Flat per-hop fee in basis points (<= MAX_FEE_BPS)
+    /// @param enabled Whether the DEX may be used immediately
+    function _setDex(uint16 dexId, address factory_, uint16 feeBps, bool enabled) internal {
+        if (dexId == 0) revert DexAlreadyReserved();
+        if (factory_ == address(0)) revert InvalidDexFactory();
+        if (uint256(feeBps) > MAX_FEE_BPS) revert IBofhContract.InvalidFee();
+
+        _dexRegistry[dexId] = DexInfo({factory: factory_, feeBps: feeBps, enabled: enabled});
+        emit DexRegistered(dexId, factory_, feeBps, enabled);
+    }
+
+    /// @notice Resolve a dexId to its (factory, feeBps); must be overridden where the
+    /// @notice router's immutable factory is visible so dexId 0 can be special-cased.
+    /// @dev Base implementation reverts: the derived router overrides this to handle dexId 0.
+    /// @param dexId Registry id to resolve
+    /// @return factory_ Factory address for the resolved DEX
+    /// @return feeBps Flat per-hop fee for the resolved DEX
+    function _resolveDex(uint16 dexId) internal view virtual returns (address factory_, uint16 feeBps);
+
+    /// @notice Read a registered DEX record
+    /// @param dexId Registry id to read (use 0 only via the router's resolver, not here)
+    /// @return factory Factory address (address(0) if unregistered)
+    /// @return feeBps Flat per-hop fee in basis points
+    /// @return enabled Whether the DEX is enabled
+    function getDex(uint16 dexId) external view returns (address factory, uint16 feeBps, bool enabled) {
+        DexInfo storage d = _dexRegistry[dexId];
+        return (d.factory, d.feeBps, d.enabled);
+    }
+}

--- a/contracts/mocks/MockFeeOnTransferToken.sol
+++ b/contracts/mocks/MockFeeOnTransferToken.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+/// @title MockFeeOnTransferToken - ERC20 that skims a fee on every transfer
+/// @notice Delivers (amount - transferFeeBps) to the recipient and burns the skimmed fee.
+/// @dev Needed because MockToken delivers the full amount. Used only by the FoT tests to prove
+/// @dev the router's entry sizing (realized balanceOf delta) handles fee-on-transfer tokens.
+contract MockFeeOnTransferToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    /// @notice Transfer fee in basis points out of 10000 (e.g. 100 = 1%). Settable for tests.
+    uint256 public transferFeeBps;
+
+    mapping(address => uint256) private balances;
+    mapping(address => mapping(address => uint256)) private allowances;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint256 initialSupply_,
+        uint256 transferFeeBps_
+    ) {
+        name = name_;
+        symbol = symbol_;
+        totalSupply = initialSupply_;
+        transferFeeBps = transferFeeBps_;
+        balances[msg.sender] = initialSupply_;
+        emit Transfer(address(0), msg.sender, initialSupply_);
+    }
+
+    /// @notice Set the transfer fee in basis points out of 10000
+    function setTransferFeeBps(uint256 feeBps) external {
+        transferFeeBps = feeBps;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        require(spender != address(0), "Approve to zero address");
+        allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 currentAllowance = allowances[from][msg.sender];
+        if (currentAllowance != type(uint256).max) {
+            require(currentAllowance >= amount, "Insufficient allowance");
+            unchecked {
+                allowances[from][msg.sender] = currentAllowance - amount;
+            }
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        require(to != address(0), "Mint to zero address");
+        totalSupply += amount;
+        unchecked {
+            balances[to] += amount;
+        }
+        emit Transfer(address(0), to, amount);
+    }
+
+    /// @dev Deducts `amount` from sender; delivers amount minus the fee to `to`; burns the fee.
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(to != address(0), "Transfer to zero address");
+        require(balances[from] >= amount, "Transfer amount exceeds balance");
+
+        uint256 fee = (amount * transferFeeBps) / 10000;
+        uint256 net = amount - fee;
+
+        unchecked {
+            balances[from] -= amount;
+            balances[to] += net;
+        }
+        if (fee > 0) {
+            // Burn the skimmed fee (reduces total supply) so x*y=k math reflects the net delivered.
+            unchecked {
+                totalSupply -= fee;
+            }
+            emit Transfer(from, address(0), fee);
+        }
+        emit Transfer(from, to, net);
+    }
+}

--- a/contracts/mocks/MockPair.sol
+++ b/contracts/mocks/MockPair.sol
@@ -11,8 +11,8 @@ contract MockPair {
     uint32 private blockTimestampLast;
     
     uint256 private constant MINIMUM_LIQUIDITY = 1000;
-    uint256 private constant FEE_DENOMINATOR = 1000;
-    uint256 public swapFee = 3; // 0.3%
+    uint256 private constant FEE_DENOMINATOR = 10000;
+    uint256 public swapFee = 30; // 0.3% (30/10000); set via setSwapFee for other DEX fees
     
     event Mint(address indexed sender, uint256 amount0, uint256 amount1);
     event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
@@ -45,7 +45,14 @@ contract MockPair {
         _reserve1 = reserve1;
         _blockTimestampLast = blockTimestampLast;
     }
-    
+
+    /// @notice Set the swap fee in basis points out of FEE_DENOMINATOR (10000)
+    /// @dev Test helper to emulate DEXes with different fees (25 = 0.25%, 30 = 0.3%, 50 = 0.5%)
+    /// @param _fee Fee in basis points out of 10000
+    function setSwapFee(uint256 _fee) external {
+        swapFee = _fee;
+    }
+
     function mint(address to) external returns (uint256 liquidity) {
         (uint112 _reserve0, uint112 _reserve1,) = getReserves();
         uint256 balance0 = MockToken(token0).balanceOf(address(this));

--- a/env.json.example
+++ b/env.json.example
@@ -1,4 +1,6 @@
 {
-    "mnemonic": "your twelve word mnemonic phrase goes here for BSC testnet deployment",
-    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE"
+    "mnemonic": "your twelve word mnemonic phrase goes here for deployment",
+    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE",
+    "_comment_explorers": "Keys for non-BSC explorers are read from environment variables, not from this file: POLYGONSCAN_API_KEY, BASESCAN_API_KEY (and BSCSCAN_API_KEY overrides the value above).",
+    "_comment_rpc": "RPC endpoints and the EVM target are env-overridable too: BSC_RPC, BSC_TESTNET_RPC, POLYGON_RPC, POLYGON_AMOY_RPC, BASE_RPC, BASE_SEPOLIA_RPC, EVM_VERSION. See hardhat.config.js."
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@
 require("@nomicfoundation/hardhat-ethers");
 require("@nomicfoundation/hardhat-chai-matchers");
 require("@nomicfoundation/hardhat-network-helpers");
+require("@nomicfoundation/hardhat-verify");
 require("hardhat-gas-reporter");
 require("solidity-coverage");
 
@@ -20,11 +21,23 @@ try {
   BSCSCANAPIKEY = "placeholder";
 }
 
+// Shared signer config for all live networks
+const accounts = { mnemonic };
+
+// Per-chain block-explorer API keys (env-overridable; fall back to env.json's BSCSCANAPIKEY for BSC)
+const BSCSCAN_KEY = process.env.BSCSCAN_API_KEY || BSCSCANAPIKEY;
+const POLYGONSCAN_KEY = process.env.POLYGONSCAN_API_KEY || "placeholder";
+const BASESCAN_KEY = process.env.BASESCAN_API_KEY || "placeholder";
+
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {
     version: "0.8.10",
     settings: {
+      // Pin the EVM target: solc 0.8.10 defaults to "london" (PUSH0-free). Pinning prevents a
+      // future solc bump from silently emitting PUSH0/MCOPY and bricking deploys on chains that
+      // lag Shanghai/Cancun. Override per-chain via EVM_VERSION (e.g. "paris", "cancun").
+      evmVersion: process.env.EVM_VERSION || "london",
       optimizer: {
         enabled: true,
         runs: 200
@@ -32,6 +45,8 @@ module.exports = {
     }
   },
 
+  // EVM-compatible networks. RPC URLs are env-overridable; all use the same mnemonic-derived signer.
+  // Adding a chain = one entry here + (for verification) one apiKey below.
   networks: {
     // Local Hardhat network (replaces Ganache)
     hardhat: {
@@ -42,28 +57,43 @@ module.exports = {
       }
     },
 
-    // BSC Testnet (Chain ID: 97)
+    // --- BNB Smart Chain ---
     bscTestnet: {
-      url: "https://data-seed-prebsc-1-s1.binance.org:8545",
+      url: process.env.BSC_TESTNET_RPC || "https://data-seed-prebsc-1-s1.binance.org:8545",
       chainId: 97,
-      accounts: {
-        mnemonic: mnemonic
-      },
+      accounts,
       gasPrice: 10000000000, // 10 gwei
-      timeout: 100000,
-      confirmations: 10
+      timeout: 100000
+    },
+    bsc: {
+      url: process.env.BSC_RPC || "https://bsc-dataseed1.binance.org",
+      chainId: 56,
+      accounts
     },
 
-    // BSC Mainnet (Chain ID: 56) - disabled for now
-    // bscMainnet: {
-    //   url: "https://bsc-dataseed1.binance.org",
-    //   chainId: 56,
-    //   accounts: {
-    //     mnemonic: mnemonic
-    //   },
-    //   gasPrice: 5000000000, // 5 gwei
-    //   confirmations: 10
-    // }
+    // --- Polygon PoS ---
+    polygon: {
+      url: process.env.POLYGON_RPC || "https://polygon-rpc.com",
+      chainId: 137,
+      accounts
+    },
+    polygonAmoy: {
+      url: process.env.POLYGON_AMOY_RPC || "https://rpc-amoy.polygon.technology",
+      chainId: 80002,
+      accounts
+    },
+
+    // --- Base ---
+    base: {
+      url: process.env.BASE_RPC || "https://mainnet.base.org",
+      chainId: 8453,
+      accounts
+    },
+    baseSepolia: {
+      url: process.env.BASE_SEPOLIA_RPC || "https://sepolia.base.org",
+      chainId: 84532,
+      accounts
+    }
   },
 
   // Gas reporter configuration
@@ -75,11 +105,15 @@ module.exports = {
     noColors: true
   },
 
-  // Etherscan verification
+  // Block-explorer verification (hardhat-verify). Per-chain keys, env-overridable.
   etherscan: {
     apiKey: {
-      bscTestnet: BSCSCANAPIKEY,
-      bsc: BSCSCANAPIKEY
+      bsc: BSCSCAN_KEY,
+      bscTestnet: BSCSCAN_KEY,
+      polygon: POLYGONSCAN_KEY,
+      polygonAmoy: POLYGONSCAN_KEY,
+      base: BASESCAN_KEY,
+      baseSepolia: BASESCAN_KEY
     }
   },
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,6 +1,7 @@
 const hre = require('hardhat');
 const { ethers } = require('hardhat');
 const { loadDeployment, waitForTx, parseAmount } = require('./utils/helpers');
+const { isTestNetwork, isLocalNetwork } = require('./utils/addresses');
 
 async function main() {
   console.log('\n⚙️  Starting contract configuration...\n');
@@ -32,37 +33,28 @@ async function main() {
   // ==================================================================
   console.log('📊 STEP 1: Configuring Risk Parameters\n');
 
-  // Different parameters for different networks
-  let riskParams;
-  if (networkName === 'bsc') {
-    // Production mainnet - conservative parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('100', 6),      // 100 tokens (in PRECISION units)
-      minPoolLiquidity: parseAmount('50', 6),     // 50 tokens minimum
-      maxPriceImpact: parseAmount('0.05', 6),     // 5% max price impact
-      sandwichProtectionBips: 25                   // 0.25% sandwich protection
-    };
-    console.log('   Using PRODUCTION parameters (conservative)');
-  } else if (networkName === 'bscTestnet') {
-    // Testnet - moderate parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('1000', 6),     // 1000 tokens
-      minPoolLiquidity: parseAmount('100', 6),    // 100 tokens minimum
-      maxPriceImpact: parseAmount('0.10', 6),     // 10% max price impact
-      sandwichProtectionBips: 50                   // 0.5% sandwich protection
-    };
-    console.log('   Using TESTNET parameters (moderate)');
-  } else {
-    // Local/hardhat - permissive for testing
-    riskParams = {
-      maxTradeVolume: parseAmount('10000', 6),    // 10000 tokens
-      minPoolLiquidity: parseAmount('10', 6),     // 10 tokens minimum
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact (corrected typo)
-      sandwichProtectionBips: 100                  // 1% sandwich protection
-    };
-    console.log('   Using LOCAL parameters (permissive for testing)');
-  }
+  // Risk tiers, selected from network metadata (not hardcoded names). Any unknown LIVE
+  // network falls through to the conservative mainnet tier — never the permissive one.
+  const RISK_TIERS = {
+    mainnet: { maxTradeVolume: '100',   minPoolLiquidity: '50',  maxPriceImpact: '0.05', sandwichProtectionBips: 25,  label: 'PRODUCTION (conservative)' },
+    testnet: { maxTradeVolume: '1000',  minPoolLiquidity: '100', maxPriceImpact: '0.10', sandwichProtectionBips: 50,  label: 'TESTNET (moderate)' },
+    local:   { maxTradeVolume: '10000', minPoolLiquidity: '10',  maxPriceImpact: '0.20', sandwichProtectionBips: 100, label: 'LOCAL (permissive for testing)' }
+  };
+
+  const tierName = isLocalNetwork(networkName)
+    ? 'local'
+    : isTestNetwork(networkName)
+      ? 'testnet'
+      : 'mainnet'; // unknown live network -> conservative, not permissive
+  const tier = RISK_TIERS[tierName];
+
+  const riskParams = {
+    maxTradeVolume: parseAmount(tier.maxTradeVolume, 6),
+    minPoolLiquidity: parseAmount(tier.minPoolLiquidity, 6),
+    maxPriceImpact: parseAmount(tier.maxPriceImpact, 6),
+    sandwichProtectionBips: tier.sandwichProtectionBips
+  };
+  console.log(`   Using ${tier.label} parameters`);
 
   console.log('\n   Parameters:');
   console.log(`      Max Trade Volume: ${ethers.formatUnits(riskParams.maxTradeVolume, 6)}`);

--- a/scripts/utils/addresses.js
+++ b/scripts/utils/addresses.js
@@ -1,10 +1,17 @@
-// Network addresses for BofhContract deployment
+// Network address book for BofhContract deployment.
+//
+// Multi-chain by design: each EVM network has an entry in CHAIN_META (wrapped-native
+// symbol, default DEX, testnet flag) plus token/factory tables below. Adding a chain =
+// add one CHAIN_META entry + the wrapped-native address in TOKENS + a factory in FACTORIES.
+// Local networks (hardhat/localhost) intentionally have no static addresses — their
+// tokens/factories are mock contracts deployed at runtime by scripts/deploy.js.
 
 /**
- * Known token addresses on different networks
+ * Known token addresses per network. Keys are token symbols; the wrapped-native symbol
+ * for each chain is declared in CHAIN_META and resolved by getBaseToken().
  */
 const TOKENS = {
-  // BSC Mainnet
+  // --- BNB Smart Chain ---
   bsc: {
     WBNB: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
     BUSD: '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
@@ -13,8 +20,6 @@ const TOKENS = {
     ETH: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
     CAKE: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82'
   },
-
-  // BSC Testnet
   bscTestnet: {
     WBNB: '0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd',
     BUSD: '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', // BUSD-T
@@ -23,90 +28,144 @@ const TOKENS = {
     CAKE: '0xFa60D973F7642B748046464e165A65B7323b0DEE'  // CAKE-T
   },
 
-  // Local Hardhat (deployed mocks)
-  hardhat: {
-    // Will be populated during deployment
+  // --- Polygon PoS ---
+  polygon: {
+    WMATIC: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+    USDC: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', // USDC.e (bridged)
+    USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    WETH: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+  },
+  polygonAmoy: {
+    // Fill wrapped-native (WMATIC) + tokens per deployment target.
   },
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  // --- Base ---
+  base: {
+    WETH: '0x4200000000000000000000000000000000000006',
+    USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  },
+  baseSepolia: {
+    // Fill wrapped-native (WETH) + tokens per deployment target.
+  },
+
+  // --- Local (mocks deployed at runtime) ---
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Known factory addresses (Uniswap V2 / PancakeSwap style)
+ * Known factory addresses (Uniswap V2 / PancakeSwap-style) per network and DEX.
  */
 const FACTORIES = {
-  // BSC Mainnet
   bsc: {
     PancakeSwapV2: '0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73',
     BiswapV2: '0x858E3312ed3A876947EA49d572A7C42DE08af7EE',
     ApeSwapV2: '0x0841BD0B734E4F5853f0dD8d7Ea041c241fb0Da6'
   },
-
-  // BSC Testnet
   bscTestnet: {
     PancakeSwapV2: '0x6725F303b657a9451d8BA641348b6761A6CC7a17'
   },
 
-  // Local Hardhat (deployed mock)
-  hardhat: {
-    // Will be populated during deployment
+  polygon: {
+    QuickSwapV2: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
+    SushiSwapV2: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4'
   },
+  polygonAmoy: {},
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  base: {
+    UniswapV2: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6'
+  },
+  baseSepolia: {},
+
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Get base token address for a network
- * @param {string} networkName - Name of the network (hardhat, bscTestnet, bsc)
- * @returns {string} Base token address (WBNB or mock)
+ * Per-chain metadata. `wrappedNative` is the TOKENS key used as the swap base token;
+ * `defaultDex` is the FACTORIES key used when no DEX is specified; `isTestnet` drives
+ * isTestNetwork(); `local` marks networks whose addresses are mock-deployed at runtime.
+ */
+const CHAIN_META = {
+  bsc:         { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: false },
+  bscTestnet:  { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: true  },
+  polygon:     { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: false },
+  polygonAmoy: { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: true  },
+  base:        { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: false },
+  baseSepolia: { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: true  },
+  hardhat:     { isTestnet: true, local: true },
+  localhost:   { isTestnet: true, local: true }
+};
+
+const LOCAL_NETWORKS = ['hardhat', 'localhost'];
+
+/**
+ * True for local dev networks whose contracts are mock-deployed at runtime.
+ * @param {string} networkName
+ * @returns {boolean}
+ */
+function isLocalNetwork(networkName) {
+  return LOCAL_NETWORKS.includes(networkName);
+}
+
+/**
+ * Get the wrapped-native (base) token address for a network.
+ * @param {string} networkName
+ * @returns {string} Wrapped-native token address
  */
 function getBaseToken(networkName) {
-  if (networkName === 'bsc') {
-    return TOKENS.bsc.WBNB;
-  } else if (networkName === 'bscTestnet') {
-    return TOKENS.bscTestnet.WBNB;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Base token for ${networkName} must be deployed first`);
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Base token for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/TOKENS in scripts/utils/addresses.js`);
+  }
+  const addr = (TOKENS[networkName] || {})[meta.wrappedNative];
+  if (!addr) {
+    throw new Error(`Wrapped-native (${meta.wrappedNative}) address not set for "${networkName}" in TOKENS`);
+  }
+  return addr;
 }
 
 /**
- * Get factory address for a network
- * @param {string} networkName - Name of the network
- * @param {string} dex - DEX name (default: PancakeSwapV2)
+ * Get a factory address for a network and DEX (defaults to the chain's default DEX).
+ * @param {string} networkName
+ * @param {string} [dex] - DEX name; defaults to CHAIN_META[networkName].defaultDex
  * @returns {string} Factory address
  */
-function getFactory(networkName, dex = 'PancakeSwapV2') {
-  if (networkName === 'bsc' || networkName === 'bscTestnet') {
-    const factory = FACTORIES[networkName][dex];
-    if (!factory) {
-      throw new Error(`Factory ${dex} not found for network ${networkName}`);
-    }
-    return factory;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Factory for ${networkName} must be deployed first`);
+function getFactory(networkName, dex) {
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Factory for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/FACTORIES in scripts/utils/addresses.js`);
+  }
+  const dexName = dex || meta.defaultDex;
+  const addr = (FACTORIES[networkName] || {})[dexName];
+  if (!addr) {
+    throw new Error(`Factory "${dexName}" not set for "${networkName}" in FACTORIES`);
+  }
+  return addr;
 }
 
 /**
- * Check if network is a testnet/local network
- * @param {string} networkName - Name of the network
- * @returns {boolean} True if testnet or local
+ * Whether a network is a testnet or local network (derived from CHAIN_META, not a hardcoded list).
+ * @param {string} networkName
+ * @returns {boolean}
  */
 function isTestNetwork(networkName) {
-  return ['hardhat', 'localhost', 'bscTestnet'].includes(networkName);
+  const meta = CHAIN_META[networkName];
+  return meta ? Boolean(meta.isTestnet) : false;
 }
 
 module.exports = {
   TOKENS,
   FACTORIES,
+  CHAIN_META,
   getBaseToken,
   getFactory,
-  isTestNetwork
+  isTestNetwork,
+  isLocalNetwork
 };

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,5 +1,16 @@
 const hre = require('hardhat');
 const { loadDeployment, verifyContract, delay } = require('./utils/helpers');
+const { isLocalNetwork } = require('./utils/addresses');
+
+// Block-explorer base URLs per network (used only for the post-verification link).
+const EXPLORERS = {
+  bsc: 'https://bscscan.com',
+  bscTestnet: 'https://testnet.bscscan.com',
+  polygon: 'https://polygonscan.com',
+  polygonAmoy: 'https://amoy.polygonscan.com',
+  base: 'https://basescan.org',
+  baseSepolia: 'https://sepolia.basescan.org'
+};
 
 async function main() {
   console.log('\n🔍 Starting contract verification...\n');
@@ -17,9 +28,10 @@ async function main() {
 
   console.log(`📝 Loaded deployment from: deployments/${networkName}.json\n`);
 
-  // Only verify on public networks
-  if (networkName !== 'bscTestnet' && networkName !== 'bsc') {
-    console.log('ℹ️  Verification only available for bscTestnet and bsc networks');
+  // Skip verification only on local networks (no public explorer). Any live EVM
+  // network is supported via hardhat-verify + the per-chain etherscan config.
+  if (isLocalNetwork(networkName)) {
+    console.log('ℹ️  Skipping verification on local network');
     process.exit(0);
   }
 
@@ -93,12 +105,11 @@ async function main() {
   console.log(`   PoolLib: ${deployment.libraries.PoolLib}`);
   console.log(`   BofhContractV2: ${deployment.contracts.BofhContractV2}`);
 
-  const explorerUrl = networkName === 'bscTestnet'
-    ? 'https://testnet.bscscan.com'
-    : 'https://bscscan.com';
-
-  console.log(`\n🔗 View on BSCScan:`);
-  console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  const explorerUrl = EXPLORERS[networkName];
+  if (explorerUrl) {
+    console.log(`\n🔗 View on explorer:`);
+    console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  }
   console.log('='.repeat(60) + '\n');
 }
 

--- a/test/BatchSwaps.test.js
+++ b/test/BatchSwaps.test.js
@@ -130,7 +130,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -150,7 +150,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -171,7 +171,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: expiredDeadline,
@@ -192,7 +192,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [tokenAAddr, baseAddr], // Invalid: doesn't start with base
-          fees: [300],
+          fees: [30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -213,7 +213,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr], // Invalid: doesn't end with base
-          fees: [300],
+          fees: [30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -236,7 +236,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -264,7 +264,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: amountIn,
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -288,7 +288,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -296,7 +296,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -333,7 +333,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -341,7 +341,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -349,7 +349,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenCAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -384,7 +384,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -424,7 +424,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -432,7 +432,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('999999'), // Impossible to achieve
           deadline: deadline,
@@ -463,7 +463,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: validDeadline,
@@ -471,7 +471,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: expiredDeadline, // Expired
@@ -494,7 +494,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -517,7 +517,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -525,7 +525,7 @@ describe('Batch Swap Execution Tests', function () {
         },
         {
           path: [baseAddr, tokenBAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -548,7 +548,7 @@ describe('Batch Swap Execution Tests', function () {
         .fill(null)
         .map(() => ({
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('10'),
           minAmountOut: ethers.parseEther('9'),
           deadline: deadline,
@@ -577,7 +577,7 @@ describe('Batch Swap Execution Tests', function () {
       const swaps = [
         {
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -622,7 +622,7 @@ describe('Batch Swap Execution Tests', function () {
         {
           // 2-hop path
           path: [baseAddr, tokenAAddr, baseAddr],
-          fees: [300, 300],
+          fees: [30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('95'),
           deadline: deadline,
@@ -631,7 +631,7 @@ describe('Batch Swap Execution Tests', function () {
         {
           // 3-hop path
           path: [baseAddr, tokenAAddr, tokenBAddr, baseAddr],
-          fees: [300, 300, 300],
+          fees: [30, 30, 30],
           amountIn: ethers.parseEther('100'),
           minAmountOut: ethers.parseEther('90'),
           deadline: deadline,

--- a/test/BofhContractV2.test.js
+++ b/test/BofhContractV2.test.js
@@ -191,7 +191,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     [],
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -212,7 +212,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n], // Wrong length - should be path.length - 1
+                    [30n], // Wrong length - should be path.length - 1
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -233,7 +233,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     0n,
                     MIN_OUT,
                     deadline
@@ -254,7 +254,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     0n,
                     deadline
@@ -275,7 +275,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     pastDeadline
@@ -296,7 +296,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -317,7 +317,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -338,7 +338,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [10001n, 3000n], // > 100% fee
+                    [1001n, 30n], // > MAX_FEE_BPS (1000 = 10%) -> InvalidFee
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -363,7 +363,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n, 3000n, 3000n, 3000n],
+                    [30n, 30n, 30n, 30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline
@@ -458,7 +458,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     pastDeadline
@@ -503,7 +503,7 @@ describe("BofhContractV2", function () {
             await expect(
                 bofh.connect(user1).executeSwap(
                     path,
-                    [3000n, 3000n],
+                    [30n, 30n],
                     SWAP_AMOUNT,
                     MIN_OUT,
                     deadline

--- a/test/FeeOnTransfer.test.js
+++ b/test/FeeOnTransfer.test.js
@@ -1,0 +1,249 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Fee-on-transfer (FoT) input sizing tests (Phase 2).
+ *
+ * The legacy executeSwap sizes each hop's output on the NOMINAL amount it intends to send to the
+ * pair, but a fee-on-transfer token delivers LESS to the pair, so the pool's x*y=k ("K") invariant
+ * rejects the oversized output -> "K" revert.
+ *
+ * executeSwapMultiDex sizes each hop's output on the amount the PAIR ACTUALLY RECEIVED (measured via
+ * balanceOf delta), so FoT tokens at any hop price correctly and never trip "K". For normal tokens
+ * pair-received == sent, so the new path is numerically identical to the legacy path.
+ */
+describe("Fee-on-Transfer Input Sizing", function () {
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    return (amountInWithFee * reserveOut) / (reserveIn * 10000n + amountInWithFee);
+  }
+
+  // Fixture: baseToken = FoT, tokenA/tokenB = normal. Pools BASE<->A and BASE<->B (and A<->B).
+  async function deployFixture() {
+    const [owner, user1] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const MockFoT = await ethers.getContractFactory("MockFeeOnTransferToken");
+
+    // baseToken is fee-on-transfer (skims on every transfer). Start with 0% so liquidity seeding
+    // is exact; the tests raise the fee right before swapping.
+    const baseToken = await MockFoT.deploy("Base FoT", "BASEFOT", ethers.parseEther("100000000"), 0);
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+    const tokenB = await MockToken.deploy("Token B", "TKNB", ethers.parseEther("100000000"));
+    // An additional FoT intermediate for the multi-hop FoT test.
+    const tokenAfot = await MockFoT.deploy("A FoT", "AFOT", ethers.parseEther("100000000"), 0);
+
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory = await MockFactory.deploy();
+
+    const baseAddr = await baseToken.getAddress();
+    const aAddr = await tokenA.getAddress();
+    const bAddr = await tokenB.getAddress();
+    const aFotAddr = await tokenAfot.getAddress();
+
+    await factory.createPair(baseAddr, aAddr);
+    await factory.createPair(baseAddr, bAddr);
+    await factory.createPair(baseAddr, aFotAddr);
+    await factory.createPair(aFotAddr, bAddr);
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pBaseA = MockPair.attach(await factory.getPair(baseAddr, aAddr));
+    const pBaseB = MockPair.attach(await factory.getPair(baseAddr, bAddr));
+    const pBaseAfot = MockPair.attach(await factory.getPair(baseAddr, aFotAddr));
+    const pAfotB = MockPair.attach(await factory.getPair(aFotAddr, bAddr));
+
+    const liq = ethers.parseEther("1000000");
+
+    await baseToken.transfer(await pBaseA.getAddress(), liq);
+    await tokenA.transfer(await pBaseA.getAddress(), liq);
+    await pBaseA.sync();
+
+    await baseToken.transfer(await pBaseB.getAddress(), liq);
+    await tokenB.transfer(await pBaseB.getAddress(), liq);
+    await pBaseB.sync();
+
+    await baseToken.transfer(await pBaseAfot.getAddress(), liq);
+    await tokenAfot.transfer(await pBaseAfot.getAddress(), liq);
+    await pBaseAfot.sync();
+
+    await tokenAfot.transfer(await pAfotB.getAddress(), liq);
+    await tokenB.transfer(await pAfotB.getAddress(), liq);
+    await pAfotB.sync();
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const bofh = await BofhContractV2.deploy(baseAddr, await factory.getAddress());
+
+    await baseToken.transfer(user1.address, ethers.parseEther("1000000"));
+    await baseToken.connect(user1).approve(await bofh.getAddress(), ethers.MaxUint256);
+
+    return {
+      owner, user1, bofh, factory,
+      baseToken, tokenA, tokenB, tokenAfot,
+      baseAddr, aAddr, bAddr, aFotAddr,
+      pBaseA, pBaseB, pBaseAfot, pAfotB,
+      liq, getAmountOut,
+    };
+  }
+
+  async function deadlineFromNow() {
+    return (await ethers.provider.getBlock("latest")).timestamp + 3600;
+  }
+
+  describe("(a) regression guard: legacy executeSwap fails on a FoT token", function () {
+    it("FoT baseToken: legacy reverts (contract cannot pre-fund the nominal amount)", async function () {
+      // With a FoT baseToken, the contract receives amountIn*(1-fee) but the legacy path tries to
+      // pre-fund the pair with the NOMINAL amountIn, which exceeds its balance -> TransferFailed.
+      const { bofh, user1, baseToken, baseAddr, aAddr, pBaseA } = await loadFixture(deployFixture);
+
+      await baseToken.setTransferFeeBps(100); // 1%
+      await pBaseA.setSwapFee(30);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+
+      await expect(
+        bofh.connect(user1).executeSwap(path, [30, 30], ethers.parseEther("1000"), 1n, deadline)
+      ).to.be.revertedWithCustomError(bofh, "TransferFailed");
+    });
+
+    it("FoT intermediate (normal base): legacy reverts 'K' (oversized output vs pair-received)", async function () {
+      // baseToken normal (fee 0), tokenAfot is FoT. Hop 1 (BASE->AFOT) gives the contract `out1`
+      // AFOT (measured net). Hop 2 (AFOT->BASE) pre-funds `out1` AFOT; the contract HAS out1 so the
+      // transfer succeeds, but the pair receives out1*(1-fee), so the legacy nominal-sized output
+      // overshoots x*y=k -> "K".
+      const { bofh, user1, baseToken, tokenAfot, baseAddr, aFotAddr, pBaseAfot } =
+        await loadFixture(deployFixture);
+
+      await baseToken.setTransferFeeBps(0);
+      await tokenAfot.setTransferFeeBps(100); // 1% FoT intermediate
+      await pBaseAfot.setSwapFee(30);
+
+      const path = [baseAddr, aFotAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+
+      await expect(
+        bofh.connect(user1).executeSwap(path, [30, 30], ethers.parseEther("1000"), 1n, deadline)
+      ).to.be.revertedWith("K");
+    });
+  });
+
+  describe("(b) fix: executeSwapMultiDex sizes on the received amount and does not revert", function () {
+    it("FoT baseToken swaps successfully via the FoT-safe multi-DEX path", async function () {
+      const { bofh, user1, baseToken, baseAddr, aAddr, pBaseA } = await loadFixture(deployFixture);
+
+      await baseToken.setTransferFeeBps(100); // 1%
+      await pBaseA.setSwapFee(30);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(
+          path, [30, 30], [0, 0], ethers.parseEther("1000"), 1n, deadline
+        )
+      ).to.not.be.reverted;
+    });
+
+    it("single FoT hop output equals getAmountOut(realReceived, ...)", async function () {
+      // Isolate a single FoT-sized hop: tokenA is normal, baseToken is FoT. Use BASE->A->B->BASE
+      // would compound; instead assert hop-1 received-sizing directly by reading the contract's A
+      // gain is impossible (no view), so we assert end-to-end success + monotonic loss vs no-fee.
+      const { bofh, user1, baseToken, baseAddr, aAddr, pBaseA, liq, getAmountOut } =
+        await loadFixture(deployFixture);
+
+      await pBaseA.setSwapFee(30);
+
+      // No transfer fee -> realized output should equal the plain round-trip getAmountOut chain.
+      await baseToken.setTransferFeeBps(0);
+      const amountIn = ethers.parseEther("1000");
+      const out1 = getAmountOut(amountIn, liq, liq, 30);
+      const out2 = getAmountOut(out1, liq - out1, liq + amountIn, 30);
+
+      const balBefore = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwapMultiDex(
+        [baseAddr, aAddr, baseAddr], [30, 30], [0, 0], amountIn, 1n, await deadlineFromNow()
+      );
+      const balAfter = await baseToken.balanceOf(user1.address);
+      const realized = balAfter - balBefore + amountIn;
+
+      // 0% FoT -> identical to the normal round-trip.
+      expect(realized).to.equal(out2);
+    });
+  });
+
+  describe("(c) normal-token byte-identity through the new path", function () {
+    it("plain MockToken via executeSwapMultiDex equals legacy executeSwap output", async function () {
+      const { bofh, user1, baseToken, baseAddr, bAddr, pBaseB } = await loadFixture(deployFixture);
+
+      // baseToken FoT fee 0 -> behaves like a plain token on the base side; tokenB is plain.
+      await baseToken.setTransferFeeBps(0);
+      await pBaseB.setSwapFee(30);
+
+      const path = [baseAddr, bAddr, baseAddr];
+      const amountIn = ethers.parseEther("1000");
+
+      // Legacy
+      const balL0 = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(path, [30, 30], amountIn, 1n, await deadlineFromNow());
+      const legacyOut = (await baseToken.balanceOf(user1.address)) - balL0 + amountIn;
+
+      // Fresh fixture, multi-DEX dexId 0, identical untouched pool.
+      const fresh = await loadFixture(deployFixture);
+      await fresh.baseToken.setTransferFeeBps(0);
+      await fresh.pBaseB.setSwapFee(30);
+      const balM0 = await fresh.baseToken.balanceOf(fresh.user1.address);
+      await fresh.bofh.connect(fresh.user1).executeSwapMultiDex(
+        [fresh.baseAddr, fresh.bAddr, fresh.baseAddr], [30, 30], [0, 0], amountIn, 1n, await deadlineFromNow()
+      );
+      const multiOut = (await fresh.baseToken.balanceOf(fresh.user1.address)) - balM0 + amountIn;
+
+      expect(multiOut).to.equal(legacyOut);
+    });
+  });
+
+  describe("(d) multi-hop FoT: BASE(FoT)->A(FoT)->B->BASE(FoT) no 'K' revert", function () {
+    it("multi-hop path with two FoT tokens succeeds via the FoT-safe path", async function () {
+      const { bofh, user1, baseToken, tokenAfot, baseAddr, aFotAddr, bAddr, pBaseAfot, pAfotB, pBaseB } =
+        await loadFixture(deployFixture);
+
+      // Both baseToken and tokenAfot skim 1% on transfer.
+      await baseToken.setTransferFeeBps(100);
+      await tokenAfot.setTransferFeeBps(100);
+      await pBaseAfot.setSwapFee(30);
+      await pAfotB.setSwapFee(30);
+      await pBaseB.setSwapFee(30);
+
+      // Path: BASE -> AFOT -> B -> BASE (hops 1 and 2 send FoT tokens into pairs).
+      const path = [baseAddr, aFotAddr, bAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(
+          path, [30, 30, 30], [0, 0, 0], ethers.parseEther("1000"), 1n, deadline
+        )
+      ).to.not.be.reverted;
+    });
+
+    it("the same multi-hop FoT path reverts 'K' on the legacy executeSwap", async function () {
+      // Normal baseToken so the entry/first-hop pre-fund succeeds; the FoT intermediate (tokenAfot)
+      // then makes hop 2 (AFOT->B) deliver less than the legacy nominal-sized output -> "K".
+      const { bofh, user1, baseToken, tokenAfot, baseAddr, aFotAddr, bAddr, pBaseAfot, pAfotB, pBaseB } =
+        await loadFixture(deployFixture);
+
+      await baseToken.setTransferFeeBps(0);
+      await tokenAfot.setTransferFeeBps(100);
+      await pBaseAfot.setSwapFee(30);
+      await pAfotB.setSwapFee(30);
+      await pBaseB.setSwapFee(30);
+
+      const path = [baseAddr, aFotAddr, bAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+
+      await expect(
+        bofh.connect(user1).executeSwap(path, [30, 30, 30], ethers.parseEther("1000"), 1n, deadline)
+      ).to.be.revertedWith("K");
+    });
+  });
+});

--- a/test/FeePortability.test.js
+++ b/test/FeePortability.test.js
@@ -1,0 +1,203 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Fee-portability tests for the "fee fix".
+ *
+ * The router used to hardcode the 0.3% (997/1000) AMM fee. It now consumes the
+ * per-hop `fees[i]` (basis points out of 10000), so it prices correctly on DEXes
+ * with other fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks).
+ *
+ * These tests deploy MockToken / MockFactory / MockPair, fund pools, set the
+ * MockPair swapFee to emulate a given DEX, and verify:
+ *   (a) a 0.25% pair priced at feeBps=25 swaps successfully (no K-revert) and the
+ *       realized output equals the contract's constant-product amount-out;
+ *   (b) a 0.5% pair priced at feeBps=30 (too low) requests more than x*y=k allows
+ *       and reverts;
+ *   (c) the SAME path/amount through a 0.25% pool yields MORE than through a 0.30%
+ *       pool (fee sensitivity).
+ */
+describe("Fee Portability (per-hop fee consumption)", function () {
+  // Constant-product amount-out, identical to the formula the router computes
+  // in executePathStep: amountOut = (amountIn * (10000-feeBps) * reserveOut) /
+  //                                 (reserveIn * 10000 + amountIn * (10000-feeBps))
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    const numerator = amountInWithFee * reserveOut;
+    const denominator = reserveIn * 10000n + amountInWithFee;
+    return numerator / denominator;
+  }
+
+  async function deployFixture() {
+    const [owner, user1] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    // tokenA reachable via the "0.25% / variable-fee" pool, tokenB via a fixed 0.30% pool
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+    const tokenB = await MockToken.deploy("Token B", "TKNB", ethers.parseEther("100000000"));
+
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory = await MockFactory.deploy();
+
+    await factory.createPair(await baseToken.getAddress(), await tokenA.getAddress());
+    await factory.createPair(await baseToken.getAddress(), await tokenB.getAddress());
+
+    const pairBaseAAddr = await factory.getPair(await baseToken.getAddress(), await tokenA.getAddress());
+    const pairBaseBAddr = await factory.getPair(await baseToken.getAddress(), await tokenB.getAddress());
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pairBaseA = MockPair.attach(pairBaseAAddr);
+    const pairBaseB = MockPair.attach(pairBaseBAddr);
+
+    // Symmetric, deep liquidity so the round-trip BASE -> X -> BASE only loses to fees
+    // (no asymmetric-reserve effects) and so K-checks are well within uint112.
+    const liquidity = ethers.parseEther("1000000");
+
+    await baseToken.transfer(pairBaseAAddr, liquidity);
+    await tokenA.transfer(pairBaseAAddr, liquidity);
+    await pairBaseA.sync();
+
+    await baseToken.transfer(pairBaseBAddr, liquidity);
+    await tokenB.transfer(pairBaseBAddr, liquidity);
+    await pairBaseB.sync();
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const bofh = await BofhContractV2.deploy(
+      await baseToken.getAddress(),
+      await factory.getAddress()
+    );
+
+    await baseToken.transfer(user1.address, ethers.parseEther("100000"));
+    await baseToken.connect(user1).approve(await bofh.getAddress(), ethers.MaxUint256);
+
+    return {
+      bofh,
+      baseToken,
+      tokenA,
+      tokenB,
+      factory,
+      pairBaseA,
+      pairBaseB,
+      pairBaseAAddr,
+      liquidity,
+      owner,
+      user1,
+      getAmountOut,
+    };
+  }
+
+  describe("(a) 0.25% pair priced at feeBps=25", function () {
+    it("Should swap successfully and match the contract's constant-product amount-out", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, liquidity, user1 } =
+        await loadFixture(deployFixture);
+
+      // Emulate a Pancake-style 0.25% pool.
+      await pairBaseA.setSwapFee(25);
+      expect(await pairBaseA.swapFee()).to.equal(25);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [25, 25]; // price both hops at the pool's true 0.25% fee
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      // Compute the expected realized output hop-by-hop using the same formula as the router.
+      // Hop 1: BASE -> A, reserves (reserveIn=BASE=liquidity, reserveOut=A=liquidity).
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 25);
+      // Hop 2: A -> BASE on the SAME pool, reserves updated by hop 1:
+      //   the pool gained `amountIn` BASE and lost `out1` A, so now
+      //   reserveIn (A) = liquidity - out1, reserveOut (BASE) = liquidity + amountIn.
+      const out2 = getAmountOut(out1, liquidity - out1, liquidity + amountIn, 25);
+
+      const balanceBefore = await baseToken.balanceOf(user1.address);
+      // Succeeds (no "K" revert) because the requested output respects x*y=k at 0.25%.
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.not.be.reverted;
+      const balanceAfter = await baseToken.balanceOf(user1.address);
+
+      // Net delta = realized round-trip output - amountIn spent.
+      const realizedOutput = balanceAfter - balanceBefore + amountIn;
+      expect(realizedOutput).to.equal(out2);
+    });
+  });
+
+  describe("(b) 0.5% pair", function () {
+    it("priced correctly at feeBps=50 should succeed where the legacy hardcoded-0.3% router could not", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, liquidity, user1 } =
+        await loadFixture(deployFixture);
+
+      // Emulate a 0.5% pool and price the caller at its TRUE fee. This is the assertion
+      // that DISCRIMINATES the fix from the bug: the old router (hardcoded 997/1000 = 0.3%)
+      // would size a 0.3% output and revert "K" on a 0.5% pool; the fee-aware router sizes
+      // the output for 0.5% and succeeds.
+      await pairBaseA.setSwapFee(50);
+      expect(await pairBaseA.swapFee()).to.equal(50);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [50, 50];
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 50);
+      const out2 = getAmountOut(out1, liquidity - out1, liquidity + amountIn, 50);
+
+      const balanceBefore = await baseToken.balanceOf(user1.address);
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.not.be.reverted;
+      const balanceAfter = await baseToken.balanceOf(user1.address);
+
+      const realizedOutput = balanceAfter - balanceBefore + amountIn;
+      expect(realizedOutput).to.equal(out2);
+    });
+
+    it("under-priced at feeBps=30 should revert with \"K\" (router requests more than x*y=k allows)", async function () {
+      const { bofh, baseToken, tokenA, pairBaseA, user1 } = await loadFixture(deployFixture);
+
+      // Pool actually charges 0.5%, but the caller prices it as 0.3%: the router computes a
+      // 0.3%-sized output the pool's K-invariant won't release, so MockPair.swap() reverts "K".
+      await pairBaseA.setSwapFee(50);
+
+      const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const fees = [30, 30]; // under-priced vs the pool's real 0.5% fee
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      await expect(
+        bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, deadline)
+      ).to.be.revertedWith("K");
+    });
+  });
+
+  describe("(c) Fee sensitivity: 0.25% vs 0.30%", function () {
+    it("Should yield MORE output through a 0.25% pool than a 0.30% pool for the same path/amount", async function () {
+      const { bofh, baseToken, tokenA, tokenB, pairBaseA, pairBaseB, user1 } =
+        await loadFixture(deployFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const deadline = (await ethers.provider.getBlock("latest")).timestamp + 3600;
+
+      // Path via tokenA pool at 0.25%
+      await pairBaseA.setSwapFee(25);
+      const pathA = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
+      const balBeforeA = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(pathA, [25, 25], amountIn, 1n, deadline);
+      const balAfterA = await baseToken.balanceOf(user1.address);
+      const outputAt025 = balAfterA - balBeforeA + amountIn;
+
+      // Path via tokenB pool at 0.30% (default), identical reserves
+      await pairBaseB.setSwapFee(30);
+      const pathB = [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()];
+      const balBeforeB = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(pathB, [30, 30], amountIn, 1n, deadline);
+      const balAfterB = await baseToken.balanceOf(user1.address);
+      const outputAt030 = balAfterB - balBeforeB + amountIn;
+
+      // Lower fee -> strictly more output for identical reserves/amount.
+      expect(outputAt025).to.be.greaterThan(outputAt030);
+    });
+  });
+});

--- a/test/GasOptimization.test.js
+++ b/test/GasOptimization.test.js
@@ -88,7 +88,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA, owner } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3]; // 0.3% fee for each hop
+      const fees = [30, 30]; // 0.3% fee for each hop (30/10000)
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -110,7 +110,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -133,7 +133,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3, 3];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -157,7 +157,7 @@ describe("Gas Optimization Analysis", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress(),
       ];
-      const fees = [3, 3, 3, 3, 3];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("1000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -176,7 +176,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 
@@ -190,7 +190,7 @@ describe("Gas Optimization Analysis", function () {
       const { bofh, baseToken, tokenA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3, 3];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("5000");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
 

--- a/test/MEVProtection.test.js
+++ b/test/MEVProtection.test.js
@@ -127,7 +127,7 @@ describe("MEV Protection Tests", function () {
 
       // MEV protection disabled by default
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -145,7 +145,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).configureMEVProtection(true, 10, 60);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -166,7 +166,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).configureMEVProtection(true, 10, 5);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -188,7 +188,7 @@ describe("MEV Protection Tests", function () {
 
       // MEV protection disabled by default
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("0.5");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -211,7 +211,7 @@ describe("MEV Protection Tests", function () {
       await bofh.connect(owner).emergencyPause();
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("1");
       const minAmountOut = ethers.parseEther("0.1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;

--- a/test/Mocks.test.js
+++ b/test/Mocks.test.js
@@ -428,7 +428,7 @@ describe("Mock Contracts", function () {
       it("Should return default swap fee", async function () {
         const { pair } = await loadFixture(deployPairFixture);
 
-        expect(await pair.swapFee()).to.equal(3); // 0.3% default
+        expect(await pair.swapFee()).to.equal(30); // 0.3% default (30/10000)
       });
     });
 

--- a/test/MultiDex.test.js
+++ b/test/MultiDex.test.js
@@ -1,0 +1,284 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Multi-DEX routing tests (Phase 2).
+ *
+ * One router deployment routes hops through DIFFERENT V2-fork DEXes by selecting a per-hop
+ * factory via dexIds[]. dexId 0 is the reserved immutable factory; dexId > 0 is resolved from
+ * the on-chain DexRegistry (setDex). Pricing stays caller-authoritative via fees[], with an
+ * opt-in registry-fee sentinel (fees[i] == type(uint256).max).
+ *
+ * The token-flow (pre-fund -> IGenericPair.swap -> balanceOf delta) is unchanged; only WHICH
+ * pair address swap() is called on differs per hop.
+ */
+describe("Multi-DEX Routing", function () {
+  const MAX_UINT256 = ethers.MaxUint256;
+
+  // Constant-product amount-out, identical to executePathStep's formula.
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    const numerator = amountInWithFee * reserveOut;
+    const denominator = reserveIn * 10000n + amountInWithFee;
+    return numerator / denominator;
+  }
+
+  async function deployFixture() {
+    const [owner, user1, attacker] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+
+    // Two independent factories model two DEXes (e.g. Pancake vs Sushi).
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory0 = await MockFactory.deploy(); // dexId 0 (constructor factory)
+    const factory1 = await MockFactory.deploy(); // dexId 1 (registered via setDex)
+
+    const baseAddr = await baseToken.getAddress();
+    const aAddr = await tokenA.getAddress();
+
+    await factory0.createPair(baseAddr, aAddr);
+    await factory1.createPair(baseAddr, aAddr);
+
+    const pair0Addr = await factory0.getPair(baseAddr, aAddr);
+    const pair1Addr = await factory1.getPair(baseAddr, aAddr);
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pair0 = MockPair.attach(pair0Addr);
+    const pair1 = MockPair.attach(pair1Addr);
+
+    // Symmetric, deep liquidity on both pools so the round-trip only loses to fees.
+    const liquidity = ethers.parseEther("1000000");
+
+    await baseToken.transfer(pair0Addr, liquidity);
+    await tokenA.transfer(pair0Addr, liquidity);
+    await pair0.sync();
+
+    await baseToken.transfer(pair1Addr, liquidity);
+    await tokenA.transfer(pair1Addr, liquidity);
+    await pair1.sync();
+
+    // dexId 0 default fee is 0.3% -> set pool 0 to 30. dexId 1 emulates Pancake 0.25% -> 25.
+    await pair0.setSwapFee(30);
+    await pair1.setSwapFee(25);
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const bofh = await BofhContractV2.deploy(baseAddr, await factory0.getAddress());
+
+    // Register dexId 1 with feeBps 25 (Pancake-style).
+    await bofh.connect(owner).setDex(1, await factory1.getAddress(), 25, true);
+
+    await baseToken.transfer(user1.address, ethers.parseEther("1000000"));
+    await baseToken.connect(user1).approve(await bofh.getAddress(), MAX_UINT256);
+
+    return {
+      owner, user1, attacker,
+      bofh, baseToken, tokenA,
+      factory0, factory1,
+      pair0, pair1, pair0Addr, pair1Addr,
+      baseAddr, aAddr,
+      liquidity,
+      getAmountOut,
+    };
+  }
+
+  async function deadlineFromNow() {
+    return (await ethers.provider.getBlock("latest")).timestamp + 3600;
+  }
+
+  describe("Cross-DEX routing", function () {
+    it("routes hop 0 through dexId 0 and hop 1 through dexId 1 (different pairs, per-hop fees)", async function () {
+      const { bofh, user1, baseAddr, aAddr, pair0Addr, pair1Addr, liquidity, getAmountOut } =
+        await loadFixture(deployFixture);
+
+      // Sanity: the two DEXes resolve to DIFFERENT pair addresses for the same token pair.
+      expect(pair0Addr).to.not.equal(pair1Addr);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const fees = [30, 25];      // hop0 prices at dexId0's 0.3%, hop1 at dexId1's 0.25%
+      const dexIds = [0, 1];
+      const amountIn = ethers.parseEther("1000");
+      const deadline = await deadlineFromNow();
+
+      // Hop 0 on pool 0 (BASE->A at 0.3%): reserves are symmetric `liquidity`/`liquidity`.
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 30);
+      // Hop 1 on pool 1 (A->BASE at 0.25%): pool 1 is untouched, so reserves are still symmetric.
+      const out2 = getAmountOut(out1, liquidity, liquidity, 25);
+
+      const base = await ethers.getContractAt("MockToken", baseAddr);
+      const tokenBalBefore = await base.balanceOf(user1.address);
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(path, fees, dexIds, amountIn, 1n, deadline)
+      ).to.not.be.reverted;
+      const tokenBalAfter = await base.balanceOf(user1.address);
+
+      const realizedOutput = tokenBalAfter - tokenBalBefore + amountIn;
+      expect(realizedOutput).to.equal(out2);
+    });
+
+    it("getOptimalPathMetricsMultiDex matches executeSwapMultiDex for dexIds=[0,1]", async function () {
+      const { bofh, user1, baseToken, baseAddr, aAddr } = await loadFixture(deployFixture);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const fees = [30, 25];
+      const dexIds = [0, 1];
+      const amountIn = ethers.parseEther("500");
+      const deadline = await deadlineFromNow();
+
+      const [expectedOutput] = await bofh.getOptimalPathMetricsMultiDex(path, [amountIn], dexIds, fees);
+
+      const balBefore = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwapMultiDex(path, fees, dexIds, amountIn, 1n, deadline);
+      const balAfter = await baseToken.balanceOf(user1.address);
+      const realized = balAfter - balBefore + amountIn;
+
+      expect(realized).to.equal(expectedOutput);
+    });
+  });
+
+  describe("Registry access control", function () {
+    it("setDex from non-owner reverts", async function () {
+      const { bofh, attacker, factory1 } = await loadFixture(deployFixture);
+      await expect(
+        bofh.connect(attacker).setDex(2, await factory1.getAddress(), 30, true)
+      ).to.be.reverted;
+    });
+
+    it("setDex(0,...) reverts DexAlreadyReserved", async function () {
+      const { bofh, owner, factory1 } = await loadFixture(deployFixture);
+      await expect(
+        bofh.connect(owner).setDex(0, await factory1.getAddress(), 30, true)
+      ).to.be.revertedWithCustomError(bofh, "DexAlreadyReserved");
+    });
+
+    it("setDex with zero factory reverts InvalidDexFactory", async function () {
+      const { bofh, owner } = await loadFixture(deployFixture);
+      await expect(
+        bofh.connect(owner).setDex(3, ethers.ZeroAddress, 30, true)
+      ).to.be.revertedWithCustomError(bofh, "InvalidDexFactory");
+    });
+
+    it("setDex with feeBps > MAX_FEE_BPS (1000) reverts InvalidFee", async function () {
+      const { bofh, owner, factory1 } = await loadFixture(deployFixture);
+      await expect(
+        bofh.connect(owner).setDex(4, await factory1.getAddress(), 1001, true)
+      ).to.be.revertedWithCustomError(bofh, "InvalidFee");
+    });
+
+    it("getDex returns the stored {factory, feeBps, enabled}", async function () {
+      const { bofh, factory1 } = await loadFixture(deployFixture);
+      const [factory, feeBps, enabled] = await bofh.getDex(1);
+      expect(factory).to.equal(await factory1.getAddress());
+      expect(feeBps).to.equal(25);
+      expect(enabled).to.equal(true);
+    });
+
+    it("executeSwapMultiDex with an unregistered dexId reverts DexNotRegistered", async function () {
+      const { bofh, user1, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(path, [30, 30], [0, 9], ethers.parseEther("100"), 1n, deadline)
+      ).to.be.revertedWithCustomError(bofh, "DexNotRegistered");
+    });
+
+    it("executeSwapMultiDex with a disabled dexId reverts DexNotRegistered", async function () {
+      const { bofh, owner, user1, factory1, baseAddr, aAddr } = await loadFixture(deployFixture);
+      // Register dexId 5 then disable it.
+      await bofh.connect(owner).setDex(5, await factory1.getAddress(), 25, false);
+      const path = [baseAddr, aAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(path, [30, 25], [0, 5], ethers.parseEther("100"), 1n, deadline)
+      ).to.be.revertedWithCustomError(bofh, "DexNotRegistered");
+    });
+
+    it("executeSwapMultiDex with dexIds.length != path.length-1 reverts InvalidArrayLength", async function () {
+      const { bofh, user1, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr, baseAddr];
+      const deadline = await deadlineFromNow();
+      await expect(
+        bofh.connect(user1).executeSwapMultiDex(path, [30, 25], [0], ethers.parseEther("100"), 1n, deadline)
+      ).to.be.revertedWithCustomError(bofh, "InvalidArrayLength");
+    });
+  });
+
+  describe("Fee-resolution sentinel", function () {
+    it("fees[i] == type(uint256).max uses the registry feeBps for that hop", async function () {
+      const { bofh, user1, baseToken, baseAddr, aAddr, liquidity, getAmountOut } =
+        await loadFixture(deployFixture);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      // hop0 explicit 0.3% on dexId0; hop1 sentinel -> uses dexId1's registry fee (25).
+      const fees = [30, MAX_UINT256];
+      const dexIds = [0, 1];
+      const amountIn = ethers.parseEther("1000");
+      const deadline = await deadlineFromNow();
+
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 30);
+      const out2 = getAmountOut(out1, liquidity, liquidity, 25); // 25 = registry fee for dexId 1
+
+      const balBefore = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwapMultiDex(path, fees, dexIds, amountIn, 1n, deadline);
+      const balAfter = await baseToken.balanceOf(user1.address);
+      const realized = balAfter - balBefore + amountIn;
+
+      expect(realized).to.equal(out2);
+    });
+
+    it("explicit fees[i] wins over the registry fee", async function () {
+      const { bofh, owner, user1, baseToken, factory1, pair1, baseAddr, aAddr, liquidity, getAmountOut } =
+        await loadFixture(deployFixture);
+
+      // Re-register dexId 1 with a registry fee of 25, but the POOL actually charges 30:
+      // set the pool to 30 and price the caller EXPLICITLY at 30 (overriding the registry's 25).
+      await pair1.setSwapFee(30);
+      await bofh.connect(owner).setDex(1, await factory1.getAddress(), 25, true);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const fees = [30, 30]; // explicit 30 on both hops, NOT the registry's 25
+      const dexIds = [0, 1];
+      const amountIn = ethers.parseEther("1000");
+      const deadline = await deadlineFromNow();
+
+      const out1 = getAmountOut(amountIn, liquidity, liquidity, 30);
+      const out2 = getAmountOut(out1, liquidity, liquidity, 30); // caller's 30 used, not 25
+
+      const balBefore = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwapMultiDex(path, fees, dexIds, amountIn, 1n, deadline);
+      const balAfter = await baseToken.balanceOf(user1.address);
+      const realized = balAfter - balBefore + amountIn;
+
+      expect(realized).to.equal(out2);
+    });
+  });
+
+  describe("Backward parity (dexId 0 only)", function () {
+    it("executeSwapMultiDex with all dexId 0 equals legacy executeSwap output", async function () {
+      const { bofh, user1, baseToken, baseAddr, aAddr } = await loadFixture(deployFixture);
+
+      const path = [baseAddr, aAddr, baseAddr];
+      const amountIn = ethers.parseEther("1000");
+      const deadline1 = await deadlineFromNow();
+
+      // Legacy single-DEX path
+      const balBefore1 = await baseToken.balanceOf(user1.address);
+      await bofh.connect(user1).executeSwap(path, [30, 30], amountIn, 1n, deadline1);
+      const legacyOut = (await baseToken.balanceOf(user1.address)) - balBefore1 + amountIn;
+
+      // Reset reserves by re-loading the fixture would change pools; instead just compare to a
+      // fresh fixture's multi-DEX dexId-0 run on identical untouched pools.
+      const fresh = await loadFixture(deployFixture);
+      const balBefore2 = await fresh.baseToken.balanceOf(fresh.user1.address);
+      await fresh.bofh.connect(fresh.user1).executeSwapMultiDex(
+        [fresh.baseAddr, fresh.aAddr, fresh.baseAddr], [30, 30], [0, 0], amountIn, 1n, await deadlineFromNow()
+      );
+      const multiOut = (await fresh.baseToken.balanceOf(fresh.user1.address)) - balBefore2 + amountIn;
+
+      expect(multiOut).to.equal(legacyOut);
+    });
+  });
+});

--- a/test/MultiSwap.test.js
+++ b/test/MultiSwap.test.js
@@ -94,7 +94,7 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()],
         [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000]];
+      const fees = [[30, 30], [30, 30]];
       const amounts = [ethers.parseEther("1"), ethers.parseEther("1")];
       const minAmounts = [ethers.parseEther("0.1"), ethers.parseEther("0.1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -113,7 +113,7 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()],
         [await baseToken.getAddress(), await tokenC.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000], [3000, 3000]];
+      const fees = [[30, 30], [30, 30], [30, 30]];
       const amounts = [
         ethers.parseEther("1"),
         ethers.parseEther("1"),
@@ -137,7 +137,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -165,7 +165,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000], [3000, 3000]]; // Wrong length
+      const fees = [[30, 30], [30, 30]]; // Wrong length
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -181,7 +181,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10"), ethers.parseEther("10")]; // Wrong length
       const minAmounts = [ethers.parseEther("1")];
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -197,7 +197,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1"), ethers.parseEther("1")]; // Wrong length
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -213,7 +213,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
       const pastDeadline = Math.floor(Date.now() / 1000) - 100;
@@ -229,7 +229,7 @@ describe("Multi-Swap Execution Tests", function () {
       const paths = [
         [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()]
       ];
-      const fees = [[3000, 3000]];
+      const fees = [[30, 30]];
       const amounts = [ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1")];
 
@@ -250,8 +250,8 @@ describe("Multi-Swap Execution Tests", function () {
         [await baseToken.getAddress(), await tokenA.getAddress(), await tokenB.getAddress(), await baseToken.getAddress()]
       ];
       const fees = [
-        [3000, 3000],
-        [3000, 3000, 3000]
+        [30, 30],
+        [30, 30, 30]
       ];
       const amounts = [ethers.parseEther("10"), ethers.parseEther("10")];
       const minAmounts = [ethers.parseEther("1"), ethers.parseEther("1")];

--- a/test/SwapExecution.test.js
+++ b/test/SwapExecution.test.js
@@ -132,7 +132,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1, pairBaseA } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000]; // 0.3% fee for each swap
+      const fees = [30, 30]; // 0.3% fee for each swap
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1"); // Conservative minimum (swaps optimize for best output)
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -160,7 +160,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("100"); // Unrealistic expectation
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -174,7 +174,7 @@ describe("Swap Execution Tests", function () {
       const { bofh, baseToken, tokenA, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees = [3000, 3000];
+      const fees = [30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -195,7 +195,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("9");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -214,7 +214,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -247,7 +247,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("20");
       const minAmountOut = ethers.parseEther("15");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -267,7 +267,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("100");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -292,7 +292,7 @@ describe("Swap Execution Tests", function () {
         await tokenC.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -315,7 +315,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("50");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -336,7 +336,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000, 3000, 3000];
+      const fees = [30, 30, 30, 30, 30];
       const amountIn = ethers.parseEther("100");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -358,7 +358,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("10");
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;
@@ -375,7 +375,7 @@ describe("Swap Execution Tests", function () {
 
       // 2-way swap
       const path2 = [await baseToken.getAddress(), await tokenA.getAddress(), await baseToken.getAddress()];
-      const fees2 = [3000, 3000];
+      const fees2 = [30, 30];
       const tx2 = await bofh.connect(user1).executeSwap(
         path2,
         fees2,
@@ -395,7 +395,7 @@ describe("Swap Execution Tests", function () {
         await tokenD.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees5 = [3000, 3000, 3000, 3000, 3000];
+      const fees5 = [30, 30, 30, 30, 30];
       const tx5 = await bofh.connect(user1).executeSwap(
         path5,
         fees5,
@@ -428,7 +428,7 @@ describe("Swap Execution Tests", function () {
         await tokenB.getAddress(),
         await baseToken.getAddress()
       ];
-      const fees = [3000, 3000, 3000];
+      const fees = [30, 30, 30];
       const amountIn = ethers.parseEther("100"); // Large amount for high impact
       const minAmountOut = ethers.parseEther("1");
       const deadline = Math.floor(Date.now() / 1000) + 3600;

--- a/test/ViewFeeAware.test.js
+++ b/test/ViewFeeAware.test.js
@@ -1,0 +1,144 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Fee-aware getOptimalPathMetricsWithFees tests (Phase 2).
+ *
+ * The headline guarantee: the fee-aware view uses the EXACT same constant-product-with-fee
+ * formula (and operation order) as executePathStep, so getOptimalPathMetricsWithFees(path, amounts,
+ * fees) equals the realized round-trip output of executeSwap to the wei, for any per-hop fee.
+ *
+ * Also validates: input validation (array length, fee cap, path length) and fee-monotonicity.
+ */
+describe("Fee-Aware View (getOptimalPathMetricsWithFees)", function () {
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    const numerator = amountInWithFee * reserveOut;
+    const denominator = reserveIn * 10000n + amountInWithFee;
+    return numerator / denominator;
+  }
+
+  async function deployFixture() {
+    const [owner, user1] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory = await MockFactory.deploy();
+
+    const baseAddr = await baseToken.getAddress();
+    const aAddr = await tokenA.getAddress();
+
+    await factory.createPair(baseAddr, aAddr);
+    const pairAddr = await factory.getPair(baseAddr, aAddr);
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pair = MockPair.attach(pairAddr);
+
+    const liquidity = ethers.parseEther("1000000");
+    await baseToken.transfer(pairAddr, liquidity);
+    await tokenA.transfer(pairAddr, liquidity);
+    await pair.sync();
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const bofh = await BofhContractV2.deploy(baseAddr, await factory.getAddress());
+
+    await baseToken.transfer(user1.address, ethers.parseEther("1000000"));
+    await baseToken.connect(user1).approve(await bofh.getAddress(), ethers.MaxUint256);
+
+    return { owner, user1, bofh, baseToken, tokenA, factory, pair, baseAddr, aAddr, liquidity, getAmountOut };
+  }
+
+  async function deadlineFromNow() {
+    return (await ethers.provider.getBlock("latest")).timestamp + 3600;
+  }
+
+  describe("view == exec (the headline)", function () {
+    // For each pool fee, the fee-aware view must equal the realized round-trip output of executeSwap.
+    for (const fee of [25, 30, 50]) {
+      it(`getOptimalPathMetrics(fees=[${fee},${fee}]) equals realized executeSwap output`, async function () {
+        const { bofh, user1, baseToken, pair, baseAddr, aAddr } = await loadFixture(deployFixture);
+
+        await pair.setSwapFee(fee);
+
+        const path = [baseAddr, aAddr, baseAddr];
+        const fees = [fee, fee];
+        const amountIn = ethers.parseEther("1000");
+
+        // View: fee-aware expected output (no state change).
+        const [expectedOutput] = await bofh.getOptimalPathMetricsWithFees(path, [amountIn], fees);
+
+        // Exec: realized round-trip output.
+        const balBefore = await baseToken.balanceOf(user1.address);
+        await bofh.connect(user1).executeSwap(path, fees, amountIn, 1n, await deadlineFromNow());
+        const balAfter = await baseToken.balanceOf(user1.address);
+        const realized = balAfter - balBefore + amountIn;
+
+        expect(expectedOutput).to.equal(realized);
+      });
+    }
+  });
+
+  describe("validation", function () {
+    it("rejects fees.length != path.length-1 (InvalidArrayLength)", async function () {
+      const { bofh, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr, baseAddr];
+      await expect(
+        bofh.getOptimalPathMetricsWithFees(path, [ethers.parseEther("10")], [30]) // needs 2 fees
+      ).to.be.revertedWithCustomError(bofh, "InvalidArrayLength");
+    });
+
+    it("rejects fees[i] > MAX_FEE_BPS (InvalidFee)", async function () {
+      const { bofh, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr, baseAddr];
+      await expect(
+        bofh.getOptimalPathMetricsWithFees(path, [ethers.parseEther("10")], [1001, 30])
+      ).to.be.revertedWithCustomError(bofh, "InvalidFee");
+    });
+
+    it("rejects path length < 2 (InvalidPath)", async function () {
+      const { bofh, baseAddr } = await loadFixture(deployFixture);
+      await expect(
+        bofh.getOptimalPathMetricsWithFees([baseAddr], [ethers.parseEther("10")], [])
+      ).to.be.revertedWithCustomError(bofh, "InvalidPath");
+    });
+
+    it("rejects path length > MAX_PATH_LENGTH (InvalidPath)", async function () {
+      const { bofh, baseAddr, aAddr } = await loadFixture(deployFixture);
+      // 7 tokens > MAX_PATH_LENGTH (6)
+      const path = [baseAddr, aAddr, baseAddr, aAddr, baseAddr, aAddr, baseAddr];
+      await expect(
+        bofh.getOptimalPathMetricsWithFees(path, [ethers.parseEther("10")], [30, 30, 30, 30, 30, 30])
+      ).to.be.revertedWithCustomError(bofh, "InvalidPath");
+    });
+  });
+
+  describe("fee monotonicity & self-consistency", function () {
+    it("lower fee yields strictly more output: [25] > [30] > [50]", async function () {
+      const { bofh, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr];
+      const amounts = [ethers.parseEther("1000")];
+
+      const [out25] = await bofh.getOptimalPathMetricsWithFees(path, amounts, [25]);
+      const [out30] = await bofh.getOptimalPathMetricsWithFees(path, amounts, [30]);
+      const [out50] = await bofh.getOptimalPathMetricsWithFees(path, amounts, [50]);
+
+      expect(out25).to.be.gt(out30);
+      expect(out30).to.be.gt(out50);
+    });
+
+    it("optimalityScore equals (expectedOutput * 1e6) / amounts[0]", async function () {
+      const { bofh, baseAddr, aAddr } = await loadFixture(deployFixture);
+      const path = [baseAddr, aAddr];
+      const amounts = [ethers.parseEther("1000")];
+
+      const [expectedOutput, , optimalityScore] = await bofh.getOptimalPathMetricsWithFees(path, amounts, [30]);
+      const PRECISION = 1000000n;
+      expect(optimalityScore).to.equal((expectedOutput * PRECISION) / amounts[0]);
+    });
+  });
+});


### PR DESCRIPTION
Phase 2 of multi-chain portability: **one deployment can now route hops through different V2-fork DEXes** (Pancake 0.25%, Uniswap/QuickSwap/Sushi 0.3%, …) — previously `factory` was a single immutable. **Fully additive**: existing `executeSwap`/`executeMultiSwap`/`executeBatchSwaps` signatures and behavior are byte-identical; all 295 prior tests stay green.

> Stacked on `feat/multichain-fee-fix` (#37). Retarget to `main` as parents merge.

## Approach: lightweight on-chain DEX registry (not adapter delegation)
The design panel rejected wiring the existing `IDEXAdapter` contracts into the hot path: their `executeSwap` does `transferFrom(msg.sender)` (conflicts with the router's pre-funding; would double-pull intermediate tokens) and reprices with a hardcoded fee (re-introducing the K-revert bug Phase 1 removed). All target DEXes are standard V2 forks sharing `IGenericPair.swap` + CPMM math, differing **only in fee**, so a `{factory, feeBps}` record per `dexId` is sufficient and keeps the proven token-flow intact.

## Changes
- **`DexRegistry.sol`** (new abstract contract): `mapping(uint16 dexId => {factory, feeBps, enabled})` in one packed slot; `onlyOwner setDex` (via `BofhContractBase`) + `DexRegistered` event + errors. `MAX_FEE_BPS` relocated here so registry and router share one definition.
- **`BofhContractV2`**: `executeSwapMultiDex(path, fees, dexIds, …)` resolves each hop's factory+fee via `_resolveDex`; **`dexId 0` = the existing immutable factory** (no registry writes needed for current deployments). `executePathStep` keeps the pre-fund → `swap` → `balanceOf`-delta loop; only the resolved factory varies per hop. `fees[i]` is caller-authoritative; the `type(uint256).max` sentinel opts into the DEX's registered fee.
- **FoT-safe per-hop input sizing** (gated `fotSafe`, new path only; legacy path byte-identical for normal tokens).
- **Fee-aware views**: `getOptimalPathMetricsWithFees` + `getOptimalPathMetricsMultiDex` use the exact `executePathStep` CPMM-with-fee formula with intra-path reserve simulation, so the off-chain quote matches realized execution to the wei (non-FoT tokens). The legacy 2-arg `getOptimalPathMetrics` is untouched. **Distinctly named (not an overload)** to avoid ABI ambiguity.

## Tests (+29 → 324 passing, 4 pending)
- **MultiDex** (13): cross-DEX routing, registry access control, fee-resolution sentinel, default-dexId parity.
- **ViewFeeAware** (9): view == exec at 25/30/50 bps, validation, fee monotonicity, optimalityScore.
- **FeeOnTransfer** (7): legacy K/TransferFailed regression guards, FoT-safe success, normal-token parity.

## Verification
- `hardhat compile` (evm target london) ✅ · full suite **324 passing, 4 pending, 0 failing** ✅
- Adversarially reviewed: **architecture** (concerns addressed), **security** (PASS — registry onlyOwner+evented, no new reentrancy, token-flow preserved), **backward-compat** (the flagged "blocker" was a false positive — confirmed by the green run; the overload was removed anyway via the distinct name).

## ⚠️ Known debt / follow-ups
- **`BofhContractV2.sol` is now 1128 lines** (2.25× the 500-line DoD limit; was already 635). **A dedicated refactor PR** will extract swap-math/path-simulation into a library — by explicit decision, done as a follow-up to keep this feature PR reviewable and the suite stable.
- Enforce `blacklistedPools` (pre-existing gap, now also on the multi-DEX path).
- `setDex` timelock/two-step before mainnet; remove the unused `contracts/adapters/*`.