### PR TITLE
feat(multichain): Phase 1 — EVM portability config & network-parametric tooling

### DIFF
--- a/env.json.example
+++ b/env.json.example
@@ -1,4 +1,6 @@
 {
-    "mnemonic": "your twelve word mnemonic phrase goes here for BSC testnet deployment",
-    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE"
+    "mnemonic": "your twelve word mnemonic phrase goes here for deployment",
+    "BSCSCANAPIKEY": "YOUR_BSCSCAN_API_KEY_HERE",
+    "_comment_explorers": "Keys for non-BSC explorers are read from environment variables, not from this file: POLYGONSCAN_API_KEY, BASESCAN_API_KEY (and BSCSCAN_API_KEY overrides the value above).",
+    "_comment_rpc": "RPC endpoints and the EVM target are env-overridable too: BSC_RPC, BSC_TESTNET_RPC, POLYGON_RPC, POLYGON_AMOY_RPC, BASE_RPC, BASE_SEPOLIA_RPC, EVM_VERSION. See hardhat.config.js."
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@
 require("@nomicfoundation/hardhat-ethers");
 require("@nomicfoundation/hardhat-chai-matchers");
 require("@nomicfoundation/hardhat-network-helpers");
+require("@nomicfoundation/hardhat-verify");
 require("hardhat-gas-reporter");
 require("solidity-coverage");
 
@@ -20,11 +21,23 @@ try {
   BSCSCANAPIKEY = "placeholder";
 }
 
+// Shared signer config for all live networks
+const accounts = { mnemonic };
+
+// Per-chain block-explorer API keys (env-overridable; fall back to env.json's BSCSCANAPIKEY for BSC)
+const BSCSCAN_KEY = process.env.BSCSCAN_API_KEY || BSCSCANAPIKEY;
+const POLYGONSCAN_KEY = process.env.POLYGONSCAN_API_KEY || "placeholder";
+const BASESCAN_KEY = process.env.BASESCAN_API_KEY || "placeholder";
+
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {
     version: "0.8.10",
     settings: {
+      // Pin the EVM target: solc 0.8.10 defaults to "london" (PUSH0-free). Pinning prevents a
+      // future solc bump from silently emitting PUSH0/MCOPY and bricking deploys on chains that
+      // lag Shanghai/Cancun. Override per-chain via EVM_VERSION (e.g. "paris", "cancun").
+      evmVersion: process.env.EVM_VERSION || "london",
       optimizer: {
         enabled: true,
         runs: 200
@@ -32,6 +45,8 @@ module.exports = {
     }
   },
 
+  // EVM-compatible networks. RPC URLs are env-overridable; all use the same mnemonic-derived signer.
+  // Adding a chain = one entry here + (for verification) one apiKey below.
   networks: {
     // Local Hardhat network (replaces Ganache)
     hardhat: {
@@ -42,28 +57,43 @@ module.exports = {
       }
     },
 
-    // BSC Testnet (Chain ID: 97)
+    // --- BNB Smart Chain ---
     bscTestnet: {
-      url: "https://data-seed-prebsc-1-s1.binance.org:8545",
+      url: process.env.BSC_TESTNET_RPC || "https://data-seed-prebsc-1-s1.binance.org:8545",
       chainId: 97,
-      accounts: {
-        mnemonic: mnemonic
-      },
+      accounts,
       gasPrice: 10000000000, // 10 gwei
-      timeout: 100000,
-      confirmations: 10
+      timeout: 100000
+    },
+    bsc: {
+      url: process.env.BSC_RPC || "https://bsc-dataseed1.binance.org",
+      chainId: 56,
+      accounts
     },
 
-    // BSC Mainnet (Chain ID: 56) - disabled for now
-    // bscMainnet: {
-    //   url: "https://bsc-dataseed1.binance.org",
-    //   chainId: 56,
-    //   accounts: {
-    //     mnemonic: mnemonic
-    //   },
-    //   gasPrice: 5000000000, // 5 gwei
-    //   confirmations: 10
-    // }
+    // --- Polygon PoS ---
+    polygon: {
+      url: process.env.POLYGON_RPC || "https://polygon-rpc.com",
+      chainId: 137,
+      accounts
+    },
+    polygonAmoy: {
+      url: process.env.POLYGON_AMOY_RPC || "https://rpc-amoy.polygon.technology",
+      chainId: 80002,
+      accounts
+    },
+
+    // --- Base ---
+    base: {
+      url: process.env.BASE_RPC || "https://mainnet.base.org",
+      chainId: 8453,
+      accounts
+    },
+    baseSepolia: {
+      url: process.env.BASE_SEPOLIA_RPC || "https://sepolia.base.org",
+      chainId: 84532,
+      accounts
+    }
   },
 
   // Gas reporter configuration
@@ -75,11 +105,15 @@ module.exports = {
     noColors: true
   },
 
-  // Etherscan verification
+  // Block-explorer verification (hardhat-verify). Per-chain keys, env-overridable.
   etherscan: {
     apiKey: {
-      bscTestnet: BSCSCANAPIKEY,
-      bsc: BSCSCANAPIKEY
+      bsc: BSCSCAN_KEY,
+      bscTestnet: BSCSCAN_KEY,
+      polygon: POLYGONSCAN_KEY,
+      polygonAmoy: POLYGONSCAN_KEY,
+      base: BASESCAN_KEY,
+      baseSepolia: BASESCAN_KEY
     }
   },
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,6 +1,7 @@
 const hre = require('hardhat');
 const { ethers } = require('hardhat');
 const { loadDeployment, waitForTx, parseAmount } = require('./utils/helpers');
+const { isTestNetwork, isLocalNetwork } = require('./utils/addresses');
 
 async function main() {
   console.log('\n⚙️  Starting contract configuration...\n');
@@ -32,37 +33,28 @@ async function main() {
   // ==================================================================
   console.log('📊 STEP 1: Configuring Risk Parameters\n');
 
-  // Different parameters for different networks
-  let riskParams;
-  if (networkName === 'bsc') {
-    // Production mainnet - conservative parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('100', 6),      // 100 tokens (in PRECISION units)
-      minPoolLiquidity: parseAmount('50', 6),     // 50 tokens minimum
-      maxPriceImpact: parseAmount('0.05', 6),     // 5% max price impact
-      sandwichProtectionBips: 25                   // 0.25% sandwich protection
-    };
-    console.log('   Using PRODUCTION parameters (conservative)');
-  } else if (networkName === 'bscTestnet') {
-    // Testnet - moderate parameters
-    riskParams = {
-      maxTradeVolume: parseAmount('1000', 6),     // 1000 tokens
-      minPoolLiquidity: parseAmount('100', 6),    // 100 tokens minimum
-      maxPriceImpact: parseAmount('0.10', 6),     // 10% max price impact
-      sandwichProtectionBips: 50                   // 0.5% sandwich protection
-    };
-    console.log('   Using TESTNET parameters (moderate)');
-  } else {
-    // Local/hardhat - permissive for testing
-    riskParams = {
-      maxTradeVolume: parseAmount('10000', 6),    // 10000 tokens
-      minPoolLiquidity: parseAmount('10', 6),     // 10 tokens minimum
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact
-      maxPriceImpact: parseAmount('0.20', 6),     // 20% max price impact (corrected typo)
-      sandwichProtectionBips: 100                  // 1% sandwich protection
-    };
-    console.log('   Using LOCAL parameters (permissive for testing)');
-  }
+  // Risk tiers, selected from network metadata (not hardcoded names). Any unknown LIVE
+  // network falls through to the conservative mainnet tier — never the permissive one.
+  const RISK_TIERS = {
+    mainnet: { maxTradeVolume: '100',   minPoolLiquidity: '50',  maxPriceImpact: '0.05', sandwichProtectionBips: 25,  label: 'PRODUCTION (conservative)' },
+    testnet: { maxTradeVolume: '1000',  minPoolLiquidity: '100', maxPriceImpact: '0.10', sandwichProtectionBips: 50,  label: 'TESTNET (moderate)' },
+    local:   { maxTradeVolume: '10000', minPoolLiquidity: '10',  maxPriceImpact: '0.20', sandwichProtectionBips: 100, label: 'LOCAL (permissive for testing)' }
+  };
+
+  const tierName = isLocalNetwork(networkName)
+    ? 'local'
+    : isTestNetwork(networkName)
+      ? 'testnet'
+      : 'mainnet'; // unknown live network -> conservative, not permissive
+  const tier = RISK_TIERS[tierName];
+
+  const riskParams = {
+    maxTradeVolume: parseAmount(tier.maxTradeVolume, 6),
+    minPoolLiquidity: parseAmount(tier.minPoolLiquidity, 6),
+    maxPriceImpact: parseAmount(tier.maxPriceImpact, 6),
+    sandwichProtectionBips: tier.sandwichProtectionBips
+  };
+  console.log(`   Using ${tier.label} parameters`);
 
   console.log('\n   Parameters:');
   console.log(`      Max Trade Volume: ${ethers.formatUnits(riskParams.maxTradeVolume, 6)}`);

--- a/scripts/utils/addresses.js
+++ b/scripts/utils/addresses.js
@@ -1,10 +1,17 @@
-// Network addresses for BofhContract deployment
+// Network address book for BofhContract deployment.
+//
+// Multi-chain by design: each EVM network has an entry in CHAIN_META (wrapped-native
+// symbol, default DEX, testnet flag) plus token/factory tables below. Adding a chain =
+// add one CHAIN_META entry + the wrapped-native address in TOKENS + a factory in FACTORIES.
+// Local networks (hardhat/localhost) intentionally have no static addresses — their
+// tokens/factories are mock contracts deployed at runtime by scripts/deploy.js.
 
 /**
- * Known token addresses on different networks
+ * Known token addresses per network. Keys are token symbols; the wrapped-native symbol
+ * for each chain is declared in CHAIN_META and resolved by getBaseToken().
  */
 const TOKENS = {
-  // BSC Mainnet
+  // --- BNB Smart Chain ---
   bsc: {
     WBNB: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
     BUSD: '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
@@ -13,8 +20,6 @@ const TOKENS = {
     ETH: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
     CAKE: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82'
   },
-
-  // BSC Testnet
   bscTestnet: {
     WBNB: '0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd',
     BUSD: '0xeD24FC36d5Ee211Ea25A80239Fb8C4Cfd80f12Ee', // BUSD-T
@@ -23,90 +28,144 @@ const TOKENS = {
     CAKE: '0xFa60D973F7642B748046464e165A65B7323b0DEE'  // CAKE-T
   },
 
-  // Local Hardhat (deployed mocks)
-  hardhat: {
-    // Will be populated during deployment
+  // --- Polygon PoS ---
+  polygon: {
+    WMATIC: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+    USDC: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', // USDC.e (bridged)
+    USDT: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+    WETH: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'
+  },
+  polygonAmoy: {
+    // Fill wrapped-native (WMATIC) + tokens per deployment target.
   },
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  // --- Base ---
+  base: {
+    WETH: '0x4200000000000000000000000000000000000006',
+    USDC: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+  },
+  baseSepolia: {
+    // Fill wrapped-native (WETH) + tokens per deployment target.
+  },
+
+  // --- Local (mocks deployed at runtime) ---
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Known factory addresses (Uniswap V2 / PancakeSwap style)
+ * Known factory addresses (Uniswap V2 / PancakeSwap-style) per network and DEX.
  */
 const FACTORIES = {
-  // BSC Mainnet
   bsc: {
     PancakeSwapV2: '0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73',
     BiswapV2: '0x858E3312ed3A876947EA49d572A7C42DE08af7EE',
     ApeSwapV2: '0x0841BD0B734E4F5853f0dD8d7Ea041c241fb0Da6'
   },
-
-  // BSC Testnet
   bscTestnet: {
     PancakeSwapV2: '0x6725F303b657a9451d8BA641348b6761A6CC7a17'
   },
 
-  // Local Hardhat (deployed mock)
-  hardhat: {
-    // Will be populated during deployment
+  polygon: {
+    QuickSwapV2: '0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32',
+    SushiSwapV2: '0xc35DADB65012eC5796536bD9864eD8773aBc74C4'
   },
+  polygonAmoy: {},
 
-  localhost: {
-    // Will be populated during deployment
-  }
+  base: {
+    UniswapV2: '0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6'
+  },
+  baseSepolia: {},
+
+  hardhat: {},
+  localhost: {}
 };
 
 /**
- * Get base token address for a network
- * @param {string} networkName - Name of the network (hardhat, bscTestnet, bsc)
- * @returns {string} Base token address (WBNB or mock)
+ * Per-chain metadata. `wrappedNative` is the TOKENS key used as the swap base token;
+ * `defaultDex` is the FACTORIES key used when no DEX is specified; `isTestnet` drives
+ * isTestNetwork(); `local` marks networks whose addresses are mock-deployed at runtime.
+ */
+const CHAIN_META = {
+  bsc:         { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: false },
+  bscTestnet:  { wrappedNative: 'WBNB',   defaultDex: 'PancakeSwapV2', isTestnet: true  },
+  polygon:     { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: false },
+  polygonAmoy: { wrappedNative: 'WMATIC', defaultDex: 'QuickSwapV2',   isTestnet: true  },
+  base:        { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: false },
+  baseSepolia: { wrappedNative: 'WETH',   defaultDex: 'UniswapV2',     isTestnet: true  },
+  hardhat:     { isTestnet: true, local: true },
+  localhost:   { isTestnet: true, local: true }
+};
+
+const LOCAL_NETWORKS = ['hardhat', 'localhost'];
+
+/**
+ * True for local dev networks whose contracts are mock-deployed at runtime.
+ * @param {string} networkName
+ * @returns {boolean}
+ */
+function isLocalNetwork(networkName) {
+  return LOCAL_NETWORKS.includes(networkName);
+}
+
+/**
+ * Get the wrapped-native (base) token address for a network.
+ * @param {string} networkName
+ * @returns {string} Wrapped-native token address
  */
 function getBaseToken(networkName) {
-  if (networkName === 'bsc') {
-    return TOKENS.bsc.WBNB;
-  } else if (networkName === 'bscTestnet') {
-    return TOKENS.bscTestnet.WBNB;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Base token for ${networkName} must be deployed first`);
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Base token for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/TOKENS in scripts/utils/addresses.js`);
+  }
+  const addr = (TOKENS[networkName] || {})[meta.wrappedNative];
+  if (!addr) {
+    throw new Error(`Wrapped-native (${meta.wrappedNative}) address not set for "${networkName}" in TOKENS`);
+  }
+  return addr;
 }
 
 /**
- * Get factory address for a network
- * @param {string} networkName - Name of the network
- * @param {string} dex - DEX name (default: PancakeSwapV2)
+ * Get a factory address for a network and DEX (defaults to the chain's default DEX).
+ * @param {string} networkName
+ * @param {string} [dex] - DEX name; defaults to CHAIN_META[networkName].defaultDex
  * @returns {string} Factory address
  */
-function getFactory(networkName, dex = 'PancakeSwapV2') {
-  if (networkName === 'bsc' || networkName === 'bscTestnet') {
-    const factory = FACTORIES[networkName][dex];
-    if (!factory) {
-      throw new Error(`Factory ${dex} not found for network ${networkName}`);
-    }
-    return factory;
-  } else {
-    // For local networks, must be set after mock deployment
-    throw new Error(`Factory for ${networkName} must be deployed first`);
+function getFactory(networkName, dex) {
+  if (isLocalNetwork(networkName)) {
+    throw new Error(`Factory for local network "${networkName}" is a mock deployed at runtime`);
   }
+  const meta = CHAIN_META[networkName];
+  if (!meta) {
+    throw new Error(`Unknown network "${networkName}" — add it to CHAIN_META/FACTORIES in scripts/utils/addresses.js`);
+  }
+  const dexName = dex || meta.defaultDex;
+  const addr = (FACTORIES[networkName] || {})[dexName];
+  if (!addr) {
+    throw new Error(`Factory "${dexName}" not set for "${networkName}" in FACTORIES`);
+  }
+  return addr;
 }
 
 /**
- * Check if network is a testnet/local network
- * @param {string} networkName - Name of the network
- * @returns {boolean} True if testnet or local
+ * Whether a network is a testnet or local network (derived from CHAIN_META, not a hardcoded list).
+ * @param {string} networkName
+ * @returns {boolean}
  */
 function isTestNetwork(networkName) {
-  return ['hardhat', 'localhost', 'bscTestnet'].includes(networkName);
+  const meta = CHAIN_META[networkName];
+  return meta ? Boolean(meta.isTestnet) : false;
 }
 
 module.exports = {
   TOKENS,
   FACTORIES,
+  CHAIN_META,
   getBaseToken,
   getFactory,
-  isTestNetwork
+  isTestNetwork,
+  isLocalNetwork
 };

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,5 +1,16 @@
 const hre = require('hardhat');
 const { loadDeployment, verifyContract, delay } = require('./utils/helpers');
+const { isLocalNetwork } = require('./utils/addresses');
+
+// Block-explorer base URLs per network (used only for the post-verification link).
+const EXPLORERS = {
+  bsc: 'https://bscscan.com',
+  bscTestnet: 'https://testnet.bscscan.com',
+  polygon: 'https://polygonscan.com',
+  polygonAmoy: 'https://amoy.polygonscan.com',
+  base: 'https://basescan.org',
+  baseSepolia: 'https://sepolia.basescan.org'
+};
 
 async function main() {
   console.log('\n🔍 Starting contract verification...\n');
@@ -17,9 +28,10 @@ async function main() {
 
   console.log(`📝 Loaded deployment from: deployments/${networkName}.json\n`);
 
-  // Only verify on public networks
-  if (networkName !== 'bscTestnet' && networkName !== 'bsc') {
-    console.log('ℹ️  Verification only available for bscTestnet and bsc networks');
+  // Skip verification only on local networks (no public explorer). Any live EVM
+  // network is supported via hardhat-verify + the per-chain etherscan config.
+  if (isLocalNetwork(networkName)) {
+    console.log('ℹ️  Skipping verification on local network');
     process.exit(0);
   }
 
@@ -93,12 +105,11 @@ async function main() {
   console.log(`   PoolLib: ${deployment.libraries.PoolLib}`);
   console.log(`   BofhContractV2: ${deployment.contracts.BofhContractV2}`);
 
-  const explorerUrl = networkName === 'bscTestnet'
-    ? 'https://testnet.bscscan.com'
-    : 'https://bscscan.com';
-
-  console.log(`\n🔗 View on BSCScan:`);
-  console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  const explorerUrl = EXPLORERS[networkName];
+  if (explorerUrl) {
+    console.log(`\n🔗 View on explorer:`);
+    console.log(`   ${explorerUrl}/address/${deployment.contracts.BofhContractV2}#code`);
+  }
   console.log('='.repeat(60) + '\n');
 }
 


### PR DESCRIPTION
Phase 1 of multi-chain EVM portability (config/tooling quick-wins). No contract behavior change.

(Replaces #36, which GitHub auto-closed when its base branch `chore/repo-hygiene` was deleted on merge of #35.)

- `hardhat.config.js`: pin `evmVersion: "london"` (env-overridable); `require("@nomicfoundation/hardhat-verify")`; add `bsc`/`polygon`/`polygonAmoy`/`base`/`baseSepolia` networks + per-chain explorer keys.
- `scripts/utils/addresses.js`: table-driven per-chain address book (CHAIN_META), generic lookups, `isLocalNetwork`; no more BSC-only throw.
- `scripts/verify.js`: skip only on local networks; per-chain explorer URLs.
- `scripts/configure.js`: risk tier from metadata, conservative default for unknown live nets.

Verified: hardhat compile (london) + full suite green.