### PR TITLE
refactor: restore reality — strip dead golden-ratio/price-impact code, correct false claims, Ownable2Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # 🏆 BofhContract V2
 
-### Advanced Multi-Path Token Swap Optimizer for Binance Smart Chain
+### Multi-Hop / Multi-DEX Atomic Swap Executor for EVM Chains
 
-**Leveraging Golden Ratio Mathematics for Provably Optimal DeFi Swaps**
+**A non-custodial sequential constant-product (x·y=k) executor with per-hop fee correctness and an owner-managed multi-DEX registry**
 
 [![Tests](https://img.shields.io/badge/tests-179%20passing-brightgreen?style=for-the-badge&logo=github)](https://github.com/Bofh-Reloaded/BofhContract)
 [![Coverage](https://img.shields.io/badge/coverage-94%25%20production-brightgreen?style=for-the-badge&logo=codecov)](https://github.com/Bofh-Reloaded/BofhContract)
@@ -80,14 +80,14 @@
 <tr>
 <td width="50%">
 
-### 🧮 Mathematical Sophistication
+### 🧮 Swap Engine
 
-- **Golden Ratio Optimization** (φ ≈ 0.618034)
-  - Provably optimal path splitting for 4/5-way swaps
-  - Lagrange multiplier-based optimization
-  - Third-order Taylor expansion for price impact
+- **Sequential CPMM Execution** (constant product, x·y=k)
+  - Multi-hop paths that start and end with `baseToken`
+  - The full amount flows through each hop (no amount-splitting)
+  - Per-hop fee correctness (Pancake 0.25%, Uniswap 0.3%, higher-fee forks)
 
-- **Advanced CPMM Analysis**
+- **CPMM Analysis**
   - Dynamic pool state analysis
   - Geometric mean liquidity calculation
   - Newton's method for precision (sqrt, cbrt)
@@ -286,10 +286,10 @@ npm run verify:testnet
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                     BofhContractV2.sol                      │
-│  Main Implementation: Swap Execution & Optimization         │
-│  • executeSwap() - Single swap execution                    │
-│  • executeMultiSwap() - Multi-path optimization             │
-│  • executeBatchSwaps() - Atomic batch operations            │
+│  Main Implementation: Multi-Hop / Multi-DEX Swap Execution  │
+│  • executeSwap() - Single multi-hop swap (one factory)      │
+│  • executeSwapMultiDex() - Per-hop multi-DEX routing        │
+│  • executeMultiSwap() / executeBatchSwaps() - Batch swaps   │
 │  Lines: 404 | Coverage: 90.83%                              │
 └──────────────────────┬──────────────────────────────────────┘
                        │ inherits
@@ -307,8 +307,8 @@ npm run verify:testnet
 ├──────────────┤ ├─────────────┤ ├──────────────┤
 │ • Reentrancy │ │ • sqrt()    │ │ • analyzePool│
 │ • Access     │ │ • cbrt()    │ │ • priceImpact│
-│ • MEV Guard  │ │ • geoMean() │ │ • validate() │
-│ • Rate Limit │ │ • goldenφ() │ │ • CPMM calc  │
+│ • MEV Guard  │ │ • log2()    │ │ • validate() │
+│ • Rate Limit │ │ • exp2()    │ │ • CPMM calc  │
 ├──────────────┤ ├─────────────┤ ├──────────────┤
 │ Lines: 300   │ │ Lines: 171  │ │ Lines: 274   │
 │ Cov: 93.48%  │ │ Cov: 100%   │ │ Cov: 95.24%  │
@@ -328,7 +328,7 @@ npm run verify:testnet
 <td><code>BofhContractV2.sol</code></td>
 <td align="right">404</td>
 <td align="center">✅ 90.83%</td>
-<td>Swap execution, golden ratio optimization, batch operations</td>
+<td>Multi-hop / multi-DEX swap execution, batch operations</td>
 </tr>
 <tr>
 <td><code>BofhContractBase.sol</code></td>
@@ -340,7 +340,7 @@ npm run verify:testnet
 <td><code>MathLib.sol</code></td>
 <td align="right">171</td>
 <td align="center">✅ 100%</td>
-<td>Newton's method (sqrt, cbrt), golden ratio, geometric mean</td>
+<td>Newton's method (sqrt, cbrt), log2/exp2 fixed-point helpers</td>
 </tr>
 <tr>
 <td><code>PoolLib.sol</code></td>
@@ -556,38 +556,30 @@ MEV Protection Tests: 8    ✅
 
 ## 🧮 Mathematical Foundations
 
-### Golden Ratio Optimization (φ ≈ 0.618034)
+### Sequential CPMM Execution (constant product, x·y=k)
 
 <table>
 <tr>
 <td width="60%">
 
-The system uses the **golden ratio** for provably optimal path splitting in multi-way swaps:
+The contract executes a **sequential multi-hop swap**: the full input amount flows
+through each hop in order, and every hop is priced with the standard
+Uniswap-V2 constant-product-with-fee formula. There is **no amount-splitting or
+golden-ratio "optimization"** — that is the off-chain path-finder's job, not the
+executor's.
 
 ```
-φ = (1 + √5) / 2 ≈ 1.618034
-φ⁻¹ ≈ 0.618034
-
-For 4-way swaps:
-  Path 1: φ⁻¹ ≈ 61.8% of total amount
-  Path 2: φ⁻² ≈ 38.2% of total amount
-  Path 3: φ⁻³ ≈ 23.6% of total amount
-  Path 4: Remainder
+For each hop (reserveIn, reserveOut, feeBps):
+  amountInWithFee = amountIn * (10000 - feeBps)
+  amountOut = (amountInWithFee * reserveOut)
+              / (reserveIn * 10000 + amountInWithFee)
 ```
 
-**Proof of Optimality:**
-
-Using Lagrange multipliers to minimize total price impact:
-
-```
-L = Σ(impact_i) + λ(Σ(amount_i) - total)
-∂L/∂amount_i = 0  ⟹  Golden ratio distribution
-```
-
-**Benefits:**
-- ✅ Provably minimizes cumulative price impact
-- ✅ Self-similar across all path counts
-- ✅ Mathematically elegant and computationally efficient
+**Properties:**
+- ✅ Atomic: all hops succeed or the whole tx reverts
+- ✅ Per-hop fee correctness (0.25% / 0.3% / higher-fee forks)
+- ✅ Paths must start and end with `baseToken`
+- ✅ Optional per-hop routing across V2 forks via an owner-managed DEX registry
 
 </td>
 <td width="40%">
@@ -612,9 +604,9 @@ Third-order Taylor expansion:
 - `ΔP/P` = relative price change
 
 **Implementation:**
-- `MathLib.sol` - Golden ratio calculations
-- `PoolLib.sol` - CPMM price impact
-- `BofhContractV2.sol` - Optimization engine
+- `MathLib.sol` - Fixed-point helpers (sqrt, cbrt, log2, exp2)
+- `PoolLib.sol` - CPMM price impact and per-hop swap validation
+- `BofhContractV2.sol` - Multi-hop / multi-DEX execution engine
 
 **Mathematical Rigor:**
 - Newton's method for √ and ∛
@@ -734,7 +726,7 @@ test/
 <tr>
 <td>Complex 4-hop swap</td>
 <td align="right"><code>~316,000</code></td>
-<td>Golden ratio optimization</td>
+<td>Multi-hop execution</td>
 </tr>
 <tr>
 <td>Complex 5-hop swap (max)</td>
@@ -1130,7 +1122,7 @@ Research and innovation in AMM optimization
 
 ## 🏆 Built with Advanced Mathematics & Security-First Design
 
-### **BofhContract V2** - *Where Golden Ratio meets DeFi*
+### **BofhContract V2** - *A non-custodial multi-hop / multi-DEX atomic swap executor*
 
 ---
 

--- a/contracts/libs/MathLib.sol
+++ b/contracts/libs/MathLib.sol
@@ -16,12 +16,6 @@ library MathLib {
     /// @notice Cube root calculation precision (100)
     uint256 private constant CBRT_PRECISION = 1e2;
 
-    /// @notice Golden ratio constant φ ≈ 0.618034 (scaled by PRECISION)
-    uint256 private constant GOLDEN_RATIO = 618034;
-
-    /// @notice Golden ratio squared φ² ≈ 0.381966 (scaled by PRECISION)
-    uint256 private constant GOLDEN_RATIO_SQUARED = 381966;
-
     /// @notice Calculate square root using Newton's method
     /// @dev Uses Newton-Raphson iteration: y_{n+1} = (y_n + x/y_n) / 2
     /// @dev Converges quadratically with better initial guess via bit length
@@ -64,26 +58,6 @@ library MathLib {
             y = (2 * y + x / ySquared) / 3;
         }
         return z;
-    }
-
-    /// @notice Calculate geometric mean of two numbers with overflow protection
-    /// @dev Geometric mean = √(a × b), uses log approximation for large numbers
-    /// @dev For a,b > uint128.max, uses log identity: √(a×b) = 2^((log₂a + log₂b)/2)
-    /// @param a First number
-    /// @param b Second number
-    /// @return Geometric mean of a and b
-    /// @custom:security Prevents overflow for values > type(uint128).max
-    /// @custom:math Geometric mean ≤ arithmetic mean (AM-GM inequality)
-    function geometricMean(uint256 a, uint256 b) internal pure returns (uint256) {
-        if (a == 0 || b == 0) return 0;
-        
-        // Use log approximation for very large numbers
-        if (a > type(uint128).max || b > type(uint128).max) {
-            uint256 logSum = (log2(a) + log2(b)) / 2;
-            return exp2(logSum);
-        }
-        
-        return sqrt(a * b);
     }
 
     /// @notice Calculate base-2 logarithm using binary search
@@ -138,34 +112,5 @@ library MathLib {
         }
         
         return sum;
-    }
-
-    /// @notice Calculate optimal amount distribution for multi-path swaps using golden ratio
-    /// @dev Implements φ-based optimization to minimize price impact across paths
-    /// @dev 3-way: Equal distribution (1/3 each)
-    /// @dev 4-way: Golden ratio φ ≈ 0.618034 distribution
-    /// @dev 5-way: Golden ratio squared φ² ≈ 0.381966 distribution
-    /// @param amount Total amount to distribute
-    /// @param pathLength Number of swap paths (3, 4, or 5)
-    /// @param position Current position in the path distribution (0-indexed)
-    /// @return Optimal amount for the given position
-    /// @custom:math Golden ratio minimizes Σ(1/xᵢ) subject to Πxᵢ = constant (Lagrange multipliers)
-    /// @custom:security Reverts if pathLength not in [3,5]
-    function calculateOptimalAmount(
-        uint256 amount,
-        uint256 pathLength,
-        uint256 position
-    ) internal pure returns (uint256) {
-        require(pathLength >= 3 && pathLength <= 5, "Invalid path length");
-
-        // Golden ratio-based optimization
-        if (pathLength == 4) {
-            return (amount * (PRECISION - (GOLDEN_RATIO * position) / pathLength)) / PRECISION;
-        } else if (pathLength == 5) {
-            return (amount * (PRECISION - (GOLDEN_RATIO_SQUARED * position) / pathLength)) / PRECISION;
-        }
-
-        // Default to equal distribution for 3-way
-        return (amount * (PRECISION - position * PRECISION / pathLength)) / PRECISION;
     }
 }

--- a/contracts/libs/PoolLib.sol
+++ b/contracts/libs/PoolLib.sol
@@ -6,7 +6,7 @@ import "../interfaces/ISwapInterfaces.sol";
 
 /// @title PoolLib - Liquidity Pool Analysis and Management Library
 /// @author Bofh Team
-/// @notice Provides advanced pool state analysis, price impact calculations, and swap optimization
+/// @notice Provides pool state analysis, price impact calculations, and per-hop swap validation
 /// @dev Implements Constant Product Market Maker (CPMM) analysis with volatility tracking
 /// @custom:security All functions validate pool liquidity and price impact constraints
 library PoolLib {
@@ -206,43 +206,6 @@ library PoolLib {
         uint256 decay = MathLib.exp2(PRECISION * timeDelta / 1 days);
 
         return (pool.volatility * decay + priceChange * (PRECISION - decay)) / PRECISION;
-    }
-
-    /// @notice Calculate optimal swap amount considering pool depth, volatility, and price impact constraints
-    /// @dev Uses square root formula to find optimal amount, then adjusts for price impact and slippage
-    /// @dev Formula: optimalAmount = √((amountIn × reserveIn × PRECISION) / (depth × (PRECISION + volatility)))
-    /// @param pool Current pool state with reserves, depth, and volatility
-    /// @param params Swap parameters including amountIn, minAmountOut, maxPriceImpact, maxSlippage
-    /// @return optimalAmount Optimized amount to swap (may be less than amountIn to meet constraints)
-    /// @return expectedOutput Expected output tokens after fees and slippage
-    /// @custom:math Minimizes slippage while respecting maxPriceImpact constraint via Lagrange multipliers
-    /// @custom:security Reverts if expectedOutput < minAmountOut (slippage protection)
-    function calculateOptimalSwapAmount(
-        PoolState memory pool,
-        SwapParams memory params
-    ) internal pure returns (uint256 optimalAmount, uint256 expectedOutput) {
-        // Base optimal amount using square root formula
-        optimalAmount = MathLib.sqrt(
-            (params.amountIn * pool.reserveIn * PRECISION) / 
-            (pool.depth * (PRECISION + pool.volatility))
-        );
-        
-        // Adjust for price impact
-        uint256 priceImpact = calculatePriceImpact(optimalAmount, pool);
-        if (priceImpact > params.maxPriceImpact) {
-            // Reduce amount to meet price impact constraint
-            optimalAmount = (optimalAmount * params.maxPriceImpact) / priceImpact;
-        }
-        
-        // Calculate expected output
-        uint256 numerator = optimalAmount * pool.reserveOut;
-        uint256 denominator = pool.reserveIn + optimalAmount;
-        expectedOutput = (numerator * (PRECISION - params.maxSlippage)) / (denominator * PRECISION);
-        
-        // Ensure minimum output is met
-        require(expectedOutput >= params.minAmountOut, "Insufficient output amount");
-        
-        return (optimalAmount, expectedOutput);
     }
 
     /// @notice Validate swap parameters and pool conditions before execution

--- a/contracts/libs/SecurityLib.sol
+++ b/contracts/libs/SecurityLib.sol
@@ -34,6 +34,7 @@ library SecurityLib {
     /// @custom:field owner Contract owner address with full permissions (20 bytes)
     /// @custom:field paused Emergency pause state (when true, most functions revert) (1 byte, packed)
     /// @custom:field locked Reentrancy guard lock (true when function is executing) (1 byte, packed)
+    /// @custom:field pendingOwner Address nominated by transferOwnership; must call acceptOwnership
     /// @custom:field lastActionTimestamp Last action timestamp for cooldown/rate limiting (32 bytes, slot 1)
     /// @custom:field globalActionCounter Total actions in current interval (32 bytes, slot 2)
     /// @custom:field operators Mapping of authorized operator addresses (separate slots)
@@ -43,17 +44,24 @@ library SecurityLib {
         address owner;              // Slot 0: bytes 0-19 (20 bytes)
         bool paused;                // Slot 0: byte 20 (1 byte, packed with owner)
         bool locked;                // Slot 0: byte 21 (1 byte, packed with owner and paused)
-        uint256 lastActionTimestamp;    // Slot 1: full slot (32 bytes)
-        uint256 globalActionCounter;    // Slot 2: full slot (32 bytes)
-        mapping(address => bool) operators;            // Slot 3+: mappings always separate
+        address pendingOwner;       // Slot 1: bytes 0-19 (two-step ownership handoff target)
+        uint256 lastActionTimestamp;    // Slot 2: full slot (32 bytes)
+        uint256 globalActionCounter;    // Slot 3: full slot (32 bytes)
+        mapping(address => bool) operators;            // Slot 4+: mappings always separate
         mapping(bytes4 => uint256) functionCooldowns;  // Slot N+: mappings always separate
         mapping(address => uint256) userActionCounts;  // Slot M+: mappings always separate
     }
 
-    /// @notice Emitted when contract ownership is transferred
+    /// @notice Emitted when ownership of the contract is completed (acceptOwnership)
     /// @param previousOwner Address of the previous owner
     /// @param newOwner Address of the new owner
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Emitted when an ownership transfer is initiated (transferOwnership)
+    /// @dev Step 1 of the two-step (Ownable2Step) handoff; the nominee must call acceptOwnership
+    /// @param previousOwner Current owner that initiated the transfer
+    /// @param newOwner Nominated owner that must accept to take control
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
 
     /// @notice Emitted when operator status is changed
     /// @param operator Address of the operator
@@ -136,22 +144,39 @@ library SecurityLib {
         self.locked = false;
     }
 
-    /// @notice Transfer contract ownership to a new address
-    /// @dev Only callable by current owner, validates new owner is not zero address
+    /// @notice Start a two-step ownership transfer by nominating a new owner (Ownable2Step)
+    /// @dev Step 1: only the current owner may nominate. Ownership does NOT change here; the nominee
+    /// @dev must call acceptOwnership to take control. This prevents accidentally handing the contract
+    /// @dev to a wrong/uncontrolled address (the classic single-step transferOwnership footgun).
     /// @param self Security state containing current owner
-    /// @param newOwner Address of the new owner
+    /// @param newOwner Address nominated as the next owner (must not be address(0))
     /// @custom:security Validates caller is current owner and newOwner != address(0)
-    /// @custom:security Emits OwnershipTransferred event for off-chain tracking
+    /// @custom:security Emits OwnershipTransferStarted; OwnershipTransferred fires only on acceptOwnership
     function transferOwnership(
         SecurityState storage self,
         address newOwner
     ) internal {
-        address oldOwner = self.owner;
-        if (msg.sender != oldOwner) revert Unauthorized();
+        if (msg.sender != self.owner) revert Unauthorized();
         if (newOwner == address(0)) revert InvalidAddress();
 
-        self.owner = newOwner;
-        emit OwnershipTransferred(oldOwner, newOwner);
+        self.pendingOwner = newOwner;
+        emit OwnershipTransferStarted(self.owner, newOwner);
+    }
+
+    /// @notice Complete a two-step ownership transfer (Ownable2Step)
+    /// @dev Step 2: only the address nominated by transferOwnership may accept. Promotes the
+    /// @dev pendingOwner to owner and clears the nomination. Any address that is not the current
+    /// @dev pendingOwner (including a non-pending account or address(0) before any nomination) reverts.
+    /// @param self Security state containing current owner and pendingOwner
+    /// @custom:security Reverts Unauthorized if msg.sender != pendingOwner
+    /// @custom:security Emits OwnershipTransferred for off-chain tracking
+    function acceptOwnership(SecurityState storage self) internal {
+        if (msg.sender != self.pendingOwner) revert Unauthorized();
+
+        address oldOwner = self.owner;
+        self.owner = self.pendingOwner;
+        self.pendingOwner = address(0);
+        emit OwnershipTransferred(oldOwner, self.owner);
     }
 
     /// @notice Grant or revoke operator status for an address

--- a/contracts/main/BofhContractBase.sol
+++ b/contracts/main/BofhContractBase.sol
@@ -305,13 +305,28 @@ abstract contract BofhContractBase is IBofhContractBase, DexRegistry {
         securityState.emergencyUnpause();
     }
 
-    /// @notice Transfer contract ownership to a new address
-    /// @dev Only callable by current owner, delegates to SecurityLib.transferOwnership
-    /// @param newOwner Address of new owner (must not be address(0))
+    /// @notice Start a two-step ownership transfer by nominating a new owner (Ownable2Step)
+    /// @dev Step 1 of 2: only the current owner may nominate. Ownership does NOT change until the
+    /// @dev nominee calls acceptOwnership(), preventing an irreversible transfer to a wrong address.
+    /// @param newOwner Address nominated as the next owner (must not be address(0))
     /// @custom:security Validates newOwner != address(0) in SecurityLib
-    /// @custom:security Emits OwnershipTransferred event via SecurityLib
+    /// @custom:security Emits OwnershipTransferStarted via SecurityLib
     function transferOwnership(address newOwner) external onlyOwner {
         securityState.transferOwnership(newOwner);
+    }
+
+    /// @notice Accept a pending ownership transfer (Ownable2Step)
+    /// @dev Step 2 of 2: only the address nominated via transferOwnership() may accept. Any other
+    /// @dev caller (including one with no pending nomination) reverts Unauthorized.
+    /// @custom:security Promotes pendingOwner to owner and emits OwnershipTransferred via SecurityLib
+    function acceptOwnership() external {
+        securityState.acceptOwnership();
+    }
+
+    /// @notice Get the address nominated to become the next owner (zero if none pending)
+    /// @return The pending owner address awaiting acceptOwnership()
+    function pendingOwner() external view returns (address) {
+        return securityState.pendingOwner;
     }
 
     /// @notice Grant or revoke operator status for an address

--- a/contracts/main/BofhContractV2.sol
+++ b/contracts/main/BofhContractV2.sol
@@ -6,12 +6,17 @@ import "../interfaces/ISwapInterfaces.sol";
 import "../interfaces/IBofhContract.sol";
 import "../libs/SwapMathLib.sol";
 
-/// @title BofhContractV2 - Advanced Multi-Path Token Swap Router
+/// @title BofhContractV2 - Multi-Hop / Multi-DEX Atomic Swap Executor
 /// @author Bofh Team
-/// @notice Executes optimized token swaps across multiple paths using golden ratio distribution
-/// @dev Implements 3/4/5-way swap path optimization with comprehensive security features
+/// @notice Executes a sequential constant-product (x*y=k) multi-hop swap across one or more
+/// @notice Uniswap-V2-style DEXes in a single atomic transaction. Every path must start and end
+/// @notice with baseToken; each hop is priced with the correct per-hop fee.
+/// @dev Walks the path hop-by-hop (pre-fund -> IGenericPair.swap -> balanceOf delta). Hops may route
+/// @dev through different V2 forks via an owner-managed DEX registry (executeSwapMultiDex). There is
+/// @dev NO amount-splitting or golden-ratio optimization; the full amount flows through each hop.
 /// @custom:security Inherits security from BofhContractBase (reentrancy, access control, MEV protection)
-/// @custom:optimization Uses golden ratio (φ ≈ 0.618034) for 4-way and 5-way path distribution
+/// @custom:fee Per-hop fee is caller-supplied (or resolved from the DEX registry) so pricing is exact
+/// @custom:fee on forks with non-0.3% fees (Pancake 0.25%, Uniswap 0.3%, higher-fee forks)
 contract BofhContractV2 is BofhContractBase, IBofhContract {
     using MathLib for uint256;
     using PoolLib for PoolLib.PoolState;
@@ -195,13 +200,11 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         // Validate final output
         if (state.currentAmount < minAmountOut) revert InsufficientOutput();
 
-        // Calculate total price impact and validate
-        // Gas optimization: Use unchecked for multiplication (overflow not possible with PRECISION = 1e6)
-        uint256 priceImpact;
-        unchecked {
-            priceImpact = (state.cumulativeImpact * PRECISION) / amountIn;
-        }
-        if (priceImpact > maxPriceImpact) revert ExcessiveSlippage();
+        // The real price-impact cap is enforced PER HOP by PoolLib.validateSwap (each hop reverts
+        // if its impact exceeds maxPriceImpact). The previously-here cumulative gate divided the
+        // summed impact by amountIn, which is dimensionally broken (truncates to 0 for realistic
+        // 18-decimal trades) and never fired, so it was removed. cumulativeImpact is still summed
+        // and surfaced in the SwapExecuted event for off-chain analytics.
 
         // Transfer profit to recipient (Phase 3: optimized)
         SwapMathLib.safeTransfer(baseToken, recipient, state.currentAmount);
@@ -211,7 +214,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             pathLength,
             amountIn,
             state.currentAmount,
-            priceImpact
+            state.cumulativeImpact
         );
 
         return state.currentAmount;
@@ -430,12 +433,9 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
         // Validate final output
         if (state.currentAmount < minAmountOut) revert InsufficientOutput();
 
-        // Calculate total price impact and validate (uses nominal amountIn, matching legacy path)
-        uint256 priceImpact;
-        unchecked {
-            priceImpact = (state.cumulativeImpact * PRECISION) / amountIn;
-        }
-        if (priceImpact > maxPriceImpact) revert ExcessiveSlippage();
+        // Per-hop PoolLib.validateSwap enforces the real maxPriceImpact cap (see the legacy path).
+        // The old cumulative gate was dimensionally broken (always 0) and has been removed.
+        // cumulativeImpact remains summed and is surfaced in the SwapExecuted event.
 
         // Transfer profit to caller
         SwapMathLib.safeTransfer(baseToken, msg.sender, state.currentAmount);
@@ -445,7 +445,7 @@ contract BofhContractV2 is BofhContractBase, IBofhContract {
             pathLength,
             amountIn,
             state.currentAmount,
-            priceImpact
+            state.cumulativeImpact
         );
 
         return state.currentAmount;

--- a/contracts/mocks/MathLibTest.sol
+++ b/contracts/mocks/MathLibTest.sol
@@ -16,23 +16,11 @@ contract MathLibTest {
         return MathLib.cbrt(x);
     }
 
-    function testGeometricMean(uint256 a, uint256 b) external pure returns (uint256) {
-        return MathLib.geometricMean(a, b);
-    }
-
     function testLog2(uint256 x) external pure returns (uint256) {
         return MathLib.log2(x);
     }
 
     function testExp2(uint256 x) external pure returns (uint256) {
         return MathLib.exp2(x);
-    }
-
-    function testCalculateOptimalAmount(
-        uint256 amount,
-        uint256 pathLength,
-        uint256 position
-    ) external pure returns (uint256) {
-        return MathLib.calculateOptimalAmount(amount, pathLength, position);
     }
 }

--- a/contracts/mocks/PoolLibTest.sol
+++ b/contracts/mocks/PoolLibTest.sol
@@ -32,13 +32,6 @@ contract PoolLibTest {
         return PoolLib.analyzePool(pool, tokenIn, amountIn, timestamp);
     }
 
-    function testCalculateOptimalSwapAmount(
-        PoolLib.PoolState memory pool,
-        PoolLib.SwapParams memory params
-    ) external pure returns (uint256 optimalAmount, uint256 expectedOutput) {
-        return PoolLib.calculateOptimalSwapAmount(pool, params);
-    }
-
     function testValidateSwap(
         PoolLib.PoolState memory pool,
         PoolLib.SwapParams memory params

--- a/contracts/mocks/SecurityLibTest.sol
+++ b/contracts/mocks/SecurityLibTest.sol
@@ -14,6 +14,7 @@ contract SecurityLibTest {
 
     // Events (re-declared for testing)
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+    event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner);
     event OperatorStatusChanged(address indexed operator, bool status);
     event SecurityStateChanged(bool paused, bool locked);
     event AnomalyDetected(address indexed user, bytes4 indexed selector, string reason);
@@ -50,6 +51,10 @@ contract SecurityLibTest {
 
     function testTransferOwnership(address newOwner) external {
         securityState.transferOwnership(newOwner);
+    }
+
+    function testAcceptOwnership() external {
+        securityState.acceptOwnership();
     }
 
     function testSetOperator(address operator, bool status) external {
@@ -98,6 +103,10 @@ contract SecurityLibTest {
     // Getters for testing state
     function getOwner() external view returns (address) {
         return securityState.owner;
+    }
+
+    function getPendingOwner() external view returns (address) {
+        return securityState.pendingOwner;
     }
 
     function isPaused() external view returns (bool) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,9 +45,9 @@ Rationale:
 
 #### 2. BofhContractV2
 - Main implementation contract
-- Swap execution logic
-- Path optimization
-- Price impact management
+- Sequential multi-hop / multi-DEX swap execution (constant product, x·y=k)
+- Per-hop fee correctness and owner-managed DEX registry routing
+- Price impact validation (per-hop cap via PoolLib.validateSwap)
 
 Architecture Pattern:
 ```solidity
@@ -66,9 +66,9 @@ Benefits:
 #### 3. Library System 📚
 
 ##### MathLib
-- Mathematical operations
-- Optimization algorithms
-- Numerical methods
+- Mathematical operations (sqrt, cbrt)
+- Fixed-point helpers (log2, exp2) used by pool volatility analysis
+- Numerical methods (Newton's method)
 
 Design Philosophy:
 ```solidity
@@ -208,8 +208,8 @@ struct PackedState {
 - Minimal storage operations
 
 ### 2. Execution Speed
-- Path optimization
-- Parallel computation where possible
+- Single-pass hop iteration (no on-chain path search or amount-splitting)
+- Per-hop pricing inlined via SwapMathLib
 - Efficient algorithms
 
 ## Future Extensibility 🔮

--- a/docs/SWAP_ALGORITHMS.md
+++ b/docs/SWAP_ALGORITHMS.md
@@ -1,9 +1,38 @@
-# Advanced Multi-Path Token Swap Algorithms: 
-# A Novel Approach Using Golden Ratio Optimization and Dynamic Programming
+# Multi-Hop / Multi-DEX Swap Execution
 
-## Abstract
+> **Correction notice.** Earlier versions of this document described a "golden ratio (φ)
+> optimization" for 4-way and 5-way swaps. **That optimization was never wired into the
+> production swap path** — the relevant functions (`MathLib.calculateOptimalAmount`,
+> `PoolLib.calculateOptimalSwapAmount`) had zero production callers and have been removed.
+> The sections below that discuss golden-ratio path splitting are retained only as historical
+> design notes; they do **not** describe the deployed contract. Any path-finding /
+> amount-sizing optimization belongs **off-chain**, not in the executor.
 
-This paper presents a novel approach to optimizing multi-path token swaps in decentralized exchanges (DEXs) using golden ratio-based path splitting and dynamic programming techniques. We introduce new algorithms for 4-way and 5-way swaps that achieve significant improvements in execution efficiency and price impact minimization. Our experimental results show a 43% reduction in gas consumption and a 52% improvement in price impact compared to traditional approaches.
+## What the contract actually does
+
+`BofhContractV2` is a **sequential constant-product (x·y=k) multi-hop swap executor**. The full
+input amount flows through each hop in order; each hop is priced with the standard Uniswap-V2
+constant-product-with-fee formula using a **caller-supplied (or DEX-registry-resolved) per-hop
+fee**. Every path must start and end with `baseToken`, and the whole multi-hop trade is atomic
+(all hops succeed or the transaction reverts). Hops may optionally route through different
+Uniswap-V2 forks via an owner-managed DEX registry (`executeSwapMultiDex`). There is **no
+on-chain amount-splitting or golden-ratio optimization**.
+
+For each hop with reserves `(reserveIn, reserveOut)` and fee `feeBps`:
+
+```
+amountInWithFee = amountIn * (10000 - feeBps)
+amountOut       = (amountInWithFee * reserveOut)
+                  / (reserveIn * 10000 + amountInWithFee)
+```
+
+---
+
+## Abstract (historical design note — not the shipped behavior)
+
+This section presents an earlier proposal to optimize multi-path token swaps using golden
+ratio-based path splitting and dynamic programming. It was never integrated into the deployed
+executor and is kept for historical context only.
 
 ## 1. Introduction
 

--- a/test/BofhContractV2.test.js
+++ b/test/BofhContractV2.test.js
@@ -169,10 +169,44 @@ describe("BofhContractV2", function () {
             await expect(bofh.connect(owner).emergencyUnpause()).to.not.be.reverted;
         });
 
-        it("Should allow owner to transfer ownership", async function () {
+        it("Should transfer ownership via two-step flow (Ownable2Step)", async function () {
             const { bofh, owner, user1 } = await loadFixture(deployContractsFixture);
+
+            // Step 1: owner nominates - admin is unchanged, pendingOwner is set
             await bofh.connect(owner).transferOwnership(user1.address);
+            expect(await bofh.getAdmin()).to.equal(owner.address);
+            expect(await bofh.pendingOwner()).to.equal(user1.address);
+
+            // Step 2: nominee accepts - admin updates, pendingOwner cleared
+            await bofh.connect(user1).acceptOwnership();
             expect(await bofh.getAdmin()).to.equal(user1.address);
+            expect(await bofh.pendingOwner()).to.equal(ethers.ZeroAddress);
+        });
+
+        it("Should prevent a non-pending address from accepting ownership", async function () {
+            const { bofh, owner, user1, user2 } = await loadFixture(deployContractsFixture);
+
+            await bofh.connect(owner).transferOwnership(user1.address);
+
+            // user2 is not the pending owner -> cannot accept
+            await expect(
+                bofh.connect(user2).acceptOwnership()
+            ).to.be.revertedWithCustomError(bofh, "Unauthorized");
+
+            // current owner is also not the pending owner -> cannot accept
+            await expect(
+                bofh.connect(owner).acceptOwnership()
+            ).to.be.revertedWithCustomError(bofh, "Unauthorized");
+
+            // ownership unchanged
+            expect(await bofh.getAdmin()).to.equal(owner.address);
+        });
+
+        it("Should prevent non-owner from initiating ownership transfer", async function () {
+            const { bofh, user1, user2 } = await loadFixture(deployContractsFixture);
+            await expect(
+                bofh.connect(user1).transferOwnership(user2.address)
+            ).to.be.revertedWithCustomError(bofh, "Unauthorized");
         });
 
         it("Should prevent ownership transfer to zero address", async function () {

--- a/test/Libraries.test.js
+++ b/test/Libraries.test.js
@@ -117,37 +117,6 @@ describe("Libraries", function () {
       });
     });
 
-    describe("geometricMean", function () {
-      it("Should return 0 if either input is 0", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        expect(await mathLib.testGeometricMean(0, 100)).to.equal(0);
-        expect(await mathLib.testGeometricMean(100, 0)).to.equal(0);
-        expect(await mathLib.testGeometricMean(0, 0)).to.equal(0);
-      });
-
-      it("Should calculate geometric mean for equal numbers", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        expect(await mathLib.testGeometricMean(100n, 100n)).to.equal(100n);
-        expect(await mathLib.testGeometricMean(1000000n, 1000000n)).to.equal(1000000n);
-      });
-
-      it("Should calculate geometric mean correctly", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        // GM(4, 9) = sqrt(36) = 6
-        expect(await mathLib.testGeometricMean(4n, 9n)).to.equal(6n);
-        // GM(1000000, 4000000) = sqrt(4*10^12) = 2*10^6
-        expect(await mathLib.testGeometricMean(1000000n, 4000000n)).to.equal(2000000n);
-      });
-
-      it("Should handle large numbers using log approximation", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        const large1 = ethers.MaxUint256 / 4n;
-        const large2 = ethers.MaxUint256 / 4n;
-        const result = await mathLib.testGeometricMean(large1, large2);
-        expect(result).to.be.gt(0);
-      });
-    });
-
     describe("log2", function () {
       it("Should return 0 for input 0", async function () {
         const { mathLib } = await loadFixture(deployLibraryTestsFixture);
@@ -201,59 +170,6 @@ describe("Libraries", function () {
       });
     });
 
-    describe("calculateOptimalAmount", function () {
-      it("Should reject invalid path lengths", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        await expect(
-          mathLib.testCalculateOptimalAmount(1000, 2, 0)
-        ).to.be.reverted;
-
-        await expect(
-          mathLib.testCalculateOptimalAmount(1000, 6, 0)
-        ).to.be.reverted;
-      });
-
-      it("Should calculate amounts for 3-way swaps (equal distribution)", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        const amount = 1000000n;
-
-        const pos0 = await mathLib.testCalculateOptimalAmount(amount, 3, 0);
-        const pos1 = await mathLib.testCalculateOptimalAmount(amount, 3, 1);
-        const pos2 = await mathLib.testCalculateOptimalAmount(amount, 3, 2);
-
-        // For 3-way, should be roughly equal distribution
-        expect(pos0).to.be.gt(pos1);
-        expect(pos1).to.be.gt(pos2);
-      });
-
-      it("Should calculate amounts for 4-way swaps (golden ratio)", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        const amount = 1000000n;
-
-        const pos0 = await mathLib.testCalculateOptimalAmount(amount, 4, 0);
-        const pos1 = await mathLib.testCalculateOptimalAmount(amount, 4, 1);
-        const pos2 = await mathLib.testCalculateOptimalAmount(amount, 4, 2);
-        const pos3 = await mathLib.testCalculateOptimalAmount(amount, 4, 3);
-
-        // Amounts should decrease according to golden ratio
-        expect(pos0).to.be.gt(pos1);
-        expect(pos1).to.be.gt(pos2);
-        expect(pos2).to.be.gt(pos3);
-      });
-
-      it("Should calculate amounts for 5-way swaps (golden ratio squared)", async function () {
-        const { mathLib } = await loadFixture(deployLibraryTestsFixture);
-        const amount = 1000000n;
-
-        const pos0 = await mathLib.testCalculateOptimalAmount(amount, 5, 0);
-        const pos1 = await mathLib.testCalculateOptimalAmount(amount, 5, 1);
-        const pos4 = await mathLib.testCalculateOptimalAmount(amount, 5, 4);
-
-        // Amounts should decrease
-        expect(pos0).to.be.gt(pos1);
-        expect(pos1).to.be.gt(pos4);
-      });
-    });
   });
 
   describe("PoolLib", function () {
@@ -475,35 +391,6 @@ describe("Libraries", function () {
       });
     });
 
-    describe("calculateOptimalSwapAmount", function () {
-      it("Should revert if minimum output cannot be met (insufficient liquidity)", async function () {
-        const { poolLib } = await loadFixture(deployLibraryTestsFixture);
-        const poolState = {
-          reserveIn: ethers.parseEther("1000"),
-          reserveOut: ethers.parseEther("100"), // Low liquidity out
-          sellingToken0: true,
-          tokenOut: ethers.ZeroAddress,
-          priceImpact: 0,
-          depth: ethers.parseEther("316"),
-          volatility: 10000n,
-          lastUpdateTimestamp: 0,
-          volumeAccumulator: 0
-        };
-
-        const swapParams = {
-          amountIn: ethers.parseEther("10"),
-          minAmountOut: ethers.parseEther("50"), // Unrealistic expectation
-          maxPriceImpact: 100000n,
-          deadline: Math.floor(Date.now() / 1000) + 3600,
-          maxSlippage: 10000n
-        };
-
-        await expect(
-          poolLib.testCalculateOptimalSwapAmount(poolState, swapParams)
-        ).to.be.revertedWith("Insufficient output amount");
-      });
-    });
-
     describe("validateSwap", function () {
       it("Should validate a valid swap", async function () {
         const { poolLib } = await loadFixture(deployLibraryTestsFixture);
@@ -708,17 +595,32 @@ describe("Libraries", function () {
         ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
       });
 
-      it("Should transfer ownership correctly", async function () {
+      it("Should transfer ownership in two steps (Ownable2Step)", async function () {
         const { securityLib, owner, user1 } = await loadFixture(deployLibraryTestsFixture);
 
+        // Step 1: current owner nominates - ownership does NOT change yet
         await expect(securityLib.connect(owner).testTransferOwnership(user1.address))
+          .to.emit(securityLib, "OwnershipTransferStarted")
+          .withArgs(owner.address, user1.address);
+
+        expect(await securityLib.getPendingOwner()).to.equal(user1.address);
+        // Owner is still the original owner until acceptance
+        expect(await securityLib.getOwner()).to.equal(owner.address);
+        await expect(securityLib.connect(owner).testCheckOwner()).to.not.be.reverted;
+        await expect(
+          securityLib.connect(user1).testCheckOwner()
+        ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
+
+        // Step 2: nominee accepts - ownership transfers and pendingOwner is cleared
+        await expect(securityLib.connect(user1).testAcceptOwnership())
           .to.emit(securityLib, "OwnershipTransferred")
           .withArgs(owner.address, user1.address);
 
-        // New owner should be able to perform owner actions
-        await expect(securityLib.connect(user1).testCheckOwner()).to.not.be.reverted;
+        expect(await securityLib.getOwner()).to.equal(user1.address);
+        expect(await securityLib.getPendingOwner()).to.equal(ethers.ZeroAddress);
 
-        // Old owner should not
+        // New owner can perform owner actions, old owner cannot
+        await expect(securityLib.connect(user1).testCheckOwner()).to.not.be.reverted;
         await expect(
           securityLib.connect(owner).testCheckOwner()
         ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
@@ -729,6 +631,33 @@ describe("Libraries", function () {
         await expect(
           securityLib.connect(owner).testTransferOwnership(ethers.ZeroAddress)
         ).to.be.revertedWithCustomError(securityLib, "InvalidAddress");
+      });
+
+      it("Should prevent a non-pending address from accepting ownership", async function () {
+        const { securityLib, owner, user1, user2 } = await loadFixture(deployLibraryTestsFixture);
+
+        // Nominate user1
+        await securityLib.connect(owner).testTransferOwnership(user1.address);
+
+        // A non-pending address (user2) cannot accept
+        await expect(
+          securityLib.connect(user2).testAcceptOwnership()
+        ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
+
+        // Even the current owner cannot accept (only the pending nominee can)
+        await expect(
+          securityLib.connect(owner).testAcceptOwnership()
+        ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
+
+        // Ownership remains unchanged
+        expect(await securityLib.getOwner()).to.equal(owner.address);
+      });
+
+      it("Should revert acceptOwnership when there is no pending nomination", async function () {
+        const { securityLib, user1 } = await loadFixture(deployLibraryTestsFixture);
+        await expect(
+          securityLib.connect(user1).testAcceptOwnership()
+        ).to.be.revertedWithCustomError(securityLib, "Unauthorized");
       });
     });
 

--- a/test/SwapExecution.test.js
+++ b/test/SwapExecution.test.js
@@ -236,8 +236,8 @@ describe("Swap Execution Tests", function () {
     });
   });
 
-  describe("4-Way Swap Execution (Golden Ratio Optimization)", function () {
-    it("Should execute 4-way swap with golden ratio splits", async function () {
+  describe("4-Way Swap Execution (BASE → A → B → C → BASE)", function () {
+    it("Should execute 4-way multi-hop swap", async function () {
       const { bofh, baseToken, tokenA, tokenB, tokenC, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [
@@ -257,7 +257,7 @@ describe("Swap Execution Tests", function () {
       ).to.not.be.reverted;
     });
 
-    it("Should apply golden ratio (φ ≈ 0.618) for amount distribution", async function () {
+    it("Should pass the full amount through each hop (no amount-splitting)", async function () {
       const { bofh, baseToken, tokenA, tokenB, tokenC, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [
@@ -303,7 +303,7 @@ describe("Swap Execution Tests", function () {
     });
   });
 
-  describe("5-Way Swap Execution (Complex Optimization)", function () {
+  describe("5-Way Swap Execution (max path length)", function () {
     it("Should execute 5-way swap (max path length)", async function () {
       const { bofh, baseToken, tokenA, tokenB, tokenC, tokenD, user1 } = await loadFixture(deployContractsFixture);
 
@@ -325,7 +325,7 @@ describe("Swap Execution Tests", function () {
       ).to.not.be.reverted;
     });
 
-    it("Should apply golden ratio squared (φ² ≈ 0.382) for 5-way splits", async function () {
+    it("Should execute a 5-hop swap and complete successfully", async function () {
       const { bofh, baseToken, tokenA, tokenB, tokenC, tokenD, user1 } = await loadFixture(deployContractsFixture);
 
       const path = [


### PR DESCRIPTION
A product-viability expert panel confirmed two things in the bytecode: the advertised **"golden ratio optimization" is dead code** (zero production callers — only test mocks), and the **cumulative price-impact gate is dimensionally dead** (`(cumulativeImpact * PRECISION) / amountIn` → 0 for real 18-decimal trades, never fires). This PR makes the repo stop lying and adds one hardening.

## Changes
- **Strip dead golden-ratio / optimal-amount code**: `MathLib.calculateOptimalAmount`, `geometricMean`, `GOLDEN_RATIO[_SQUARED]`; `PoolLib.calculateOptimalSwapAmount`; and the test-only mock wrappers + `Libraries.test.js` cases that existed solely to exercise them.
- **Remove the dead cumulative price-impact gate** in both the legacy and multi-DEX paths — removal is **behavior-neutral** (it never fired). The real per-hop `PoolLib.validateSwap` cap is unchanged. `SwapExecuted` now emits the raw cumulative-impact sum (no test asserted the old divided value).
- **Correct false "golden ratio (φ) optimization" claims** in `BofhContractV2`/`PoolLib` NatSpec, `README.md`, `docs/ARCHITECTURE.md`, `docs/SWAP_ALGORITHMS.md`, and misleading test titles. The contract is a **sequential CPMM (x*y=k) multi-hop / multi-DEX atomic executor** with per-hop fee correctness and an owner-managed DEX registry.
- **Ownable2Step**: `pendingOwner` + `acceptOwnership` in `SecurityLib` + `BofhContractBase`; tests updated to the two-step flow (incl. non-pending-cannot-accept) — addresses the review's single-step-ownership finding.

## Verification
- `hardhat compile` (london) ✅ · full suite **326 passing, 4 pending, 0 failing** (was 331; the −5 are the deleted dead-code tests).

## Notes
- `ExcessiveSlippage` is now unused in `BofhContractV2` but left declared in `IBofhContract` to avoid an ABI change.
- `docs/SWAP_ALGORITHMS.md` keeps its historical golden-ratio "paper" body below a prominent correction notice rather than deleting it wholesale.

Context: this lands the **reality** half of the panel's recommendation. The strategy + research-system half is in a separate PR (`feat/arb-research-system`).