### PR TITLE
feat(research): off-chain arbitrage research & backtest system + strategy report

### DIFF
--- a/docs/STRATEGY_AND_REALITY.md
+++ b/docs/STRATEGY_AND_REALITY.md
@@ -1,0 +1,210 @@
+# Strategy and Reality
+
+**Audience:** the founding team
+**Date:** 2026-06-05
+**Status:** decision document — read before spending another engineering-week or a single audit dollar
+
+This document merges three things: the verdict of the 6-expert panel, the "Reality" cleanup we just applied to the repo, and the web-grounded research on where a 2-3 person team can actually make money on-chain in 2025-2026. It is deliberately blunt. The point is to stop the project from lying to us, name the one bet worth making, and define the exact evidence that turns that bet into an audit (or a sunset).
+
+---
+
+## 1. What we made real this pass
+
+Until this cleanup, the repo advertised a product it did not contain. The headline claim — "golden ratio (φ ≈ 0.618034) optimization for 4-way and 5-way swaps" — was **dead code with zero production callers**. The only things that ever called the optimization math were test mocks. We were maintaining, documenting, and (worse) believing in a feature that never ran.
+
+This pass removed the lie. Concretely:
+
+**Dead code stripped (suite still green: 326 passing, 0 failing, 4 pending; compiles clean):**
+
+- `MathLib.calculateOptimalAmount` — the golden-ratio amount-distribution function. Zero production callers.
+- `MathLib.geometricMean` — used only by a test mock.
+- `MathLib.GOLDEN_RATIO` and `GOLDEN_RATIO_SQUARED` constants — the namesake of the whole false story.
+- `PoolLib.calculateOptimalSwapAmount` — zero production callers, only a test mock.
+- The corresponding mock wrappers (`MathLibTest`, `PoolLibTest`) and their `Libraries.test.js` describe blocks.
+- Two **dead cumulative price-impact gates** in `BofhContractV2` (`_executeSwapToRecipient` legacy path and `_executeSwapMultiDex`). These computed `priceImpact = (cumulativeImpact * PRECISION) / amountIn` and reverted with `ExcessiveSlippage()` — but the math was broken and the gate was never the real protection. The live per-hop `validateSwap` cap is unchanged and remains in force.
+
+**False claims corrected, so the repo stops describing a product it isn't:**
+
+- `contracts/main/BofhContractV2.sol` header: rewritten from "golden ratio (phi) optimization for 4/5-way swaps" to an accurate description — a **sequential constant-product (x·y=k) multi-hop / multi-DEX atomic executor with per-hop fee correctness**.
+- `contracts/libs/PoolLib.sol` header: "swap optimization" → "per-hop swap validation".
+- `README.md`: title, subtitle, feature bullets, architecture diagram/table, the "Golden Ratio Optimization" math section, the implementation list, the footer, and a gas-table cell — all corrected to describe a **non-custodial sequential CPMM multi-hop / multi-DEX executor**.
+- `docs/SWAP_ALGORITHMS.md`: retitled, with a prominent correction notice that golden-ratio optimization was never wired into production and has been removed. (The historical academic body — ~25 mentions — is retained below the notice and flagged as historical rather than deleted, to keep the diff scoped. **It should be removed entirely in a follow-up.**)
+- `docs/ARCHITECTURE.md`: the "Path optimization" and "Optimization algorithms" bullets corrected to reflect single-pass hop execution with **no on-chain optimization**.
+- `test/SwapExecution.test.js`: misleading "golden ratio" test titles renamed to describe the real multi-hop swap execution they actually exercise (the tests were kept — they test live swaps).
+
+**One structural security improvement landed in the same pass:** ownership is now **Ownable-2-step**. `transferOwnership` only nominates a `pendingOwner` and emits `OwnershipTransferStarted`; the nominee must call `acceptOwnership` to take control. This prevents a fat-finger transfer to an address nobody controls — appropriate hardening for a contract that will eventually hold or route the team's own capital.
+
+**Honest residue (tracked, not hidden):**
+
+- `ExcessiveSlippage()` is now unused inside `BofhContractV2` but remains declared in `IBofhContract.sol`. Left untouched to avoid an ABI change; no compile impact.
+- `log2` in `MathLib` is now only reachable via its test mock, but it's a legitimate fixed-point primitive paired with the production-used `exp2`. Kept, in scope.
+- `SQRT_PRECISION` / `CBRT_PRECISION` were already unused before this pass. Left as-is.
+- `SwapExecuted` now emits the **raw** cumulative price-impact sum instead of the previously-broken divided value. No test asserted the old number; the per-hop cap is unchanged. This is an analytics-field shape change worth noting for any downstream consumer.
+
+**Net effect:** the contract now says what it is. It is a clean, tested, non-custodial, multi-V2-fork atomic executor. It is **not** an optimizer, and it never was. Everything below proceeds from that corrected baseline.
+
+---
+
+## 2. The honest verdict
+
+**The contract is the commodity. The edge is off-chain, and it does not exist yet.**
+
+Stated plainly, as the panel did:
+
+1. **As a competitive arbitrage tool, the contract does not make sense on its own.** It is gas-heavy (~2-3× a Huff/Yul executor), V2-only, has no flash loans (so capital must be held on-chain, at risk, fragmented across pairs), and its advertised optimization was dead code. On contested liquid pairs, public-mempool arb is won on **gas-bid and latency**, not on a nicer Solidity executor. There, this contract is a liability, not an advantage.
+
+2. **The money-making edge is 100% off-chain** — fast new-pair discovery, a real cross-fork path-finder over live reserves, decent (not co-located) latency, and private inclusion. **None of it is in this repo.** `scripts/find-arbitrage.js` is confirmed a mock-pool demo: it deploys `MockPair`/`MockFactory`, manually transfers tokens to fabricate imbalances, hardcodes `fee=3` (wrong across forks), and loops `executeSwap` over hardcoded paths. No reserve indexer, no mempool/event listener, no path solver, no bundle submission, no live reserves.
+
+3. **Therefore we have a settlement layer and no strategy.** A settlement layer is necessary but not sufficient and — critically — **easily replaceable**. The thing that would make money (the off-chain edge) is the thing we have not built and have not proven.
+
+The trap to avoid: "refocusing" by polishing the contract first. That repeats the original mistake. We do not have a contract problem. We have an **unproven-edge** problem. Polishing or auditing the executor before the edge is proven is spending money to make the commodity shinier while the moat is still vaporware.
+
+---
+
+## 3. Where the money realistically is
+
+The research is unambiguous: **every measured on-chain extraction market in 2025-2026 is an oligopoly.** The questions that matter for us are (a) which corners are *not* yet captured, and (b) which of those make our existing asset *the right tool* rather than dead weight.
+
+### The ranked landscape
+
+| Rank | Strategy | Competition | Small-team fit | Uses our executor? | Verdict |
+|---|---|---|---|---|---|
+| **#1** | **Long-tail / fresh-launch V2-fork backrunning** (thin/under-contested chains) | soft | high | **Yes — best fit** | **RECOMMENDED** |
+| **#2** | Auction / OEV backrunning (Polygon FastLane-Atlas, Chainlink SVR, BSC bundles) | high | medium | No (executor irrelevant) | **HEDGE / fallback** |
+| 3 | Liquidation keeping (smaller/newer lending markets) | high | medium | Swap-leg only | Event-driven, bursty |
+| 4 | Cross-V2-fork atomic arb on *contested liquid* pairs | brutal | low | Best-shape, currently a liability | Money-loser for us |
+| 5 | CEX-DEX arbitrage | brutal | low | Irrelevant | Closed to us |
+| 6 | Cross-chain inventory arb | high | low | Irrelevant | Capital/inventory game |
+| 7 | JIT V3 liquidity provision | high | low | Wrong architecture (V3) | ~0.007% ROI; not for us |
+| 8 | Long-tail sniping / copy-trade bots | brutal | medium | Irrelevant | Speculation, not arb |
+
+### The brutal reasons most of these are losing games for us
+
+- **CEX-DEX (#5)** is the biggest category ($233.8M extracted Aug-2023→Mar-2025) and the most closed. Top 3 searchers take ~90% of value; they keep only ~10-15% and pay ~90% to integrated builders. No builder integration = you don't win blocks. We have no CEX inventory, no pricing engine, no co-location, no builder relationship. Entry path: none.
+- **Contested atomic V2 arb (#4)** is literally what our contract is *for*, and it's exactly the losing pattern Flashbots' "limits of scaling" describes: blind on-chain V2 search burns ~130M gas per successful arb (a documented bot sends ~350 failed txs per win — a ~650× efficiency gap vs reading state privately). BSC block construction is ~80%+ two builders (Blockrazor + 48Club); Base is ~2 entities doing 80%+ of blocks. Independent searchers retain ~17% of profit. Our gas-heavy, blind, capital-holding executor is built to lose this specific race.
+- **Cross-chain (#6)** has wider spreads (0.3-5%) but ~67% of arbs use pre-positioned dual-chain inventory; >50% of trades trace to 5 addresses. The wide spread is compensation for capital fragmentation, bridge/finality risk, and adverse selection — not free money. Our single-chain atomic executor can't make a cross-chain trade atomic.
+- **JIT V3 (#7)**: ~0.007% average ROI, needs tens of millions deployed per opportunity, wrong architecture (V3 ticks, not V2 CPMM). Nothing transfers.
+- **Retail sniping (#8)** is directional speculation, not market-neutral extraction. >60% of participants lose. Copy-trading makes you a KOL's exit liquidity. The tooling layer is saturated by funded incumbents.
+- **OEV / liquidations (#2, #3)** are genuinely permissionless and winnable on bid-math — but Chainlink SVR liquidation recapture is already **>80% with many onboarded searchers** (late and crowded), and in these venues you bid *into someone else's ordering* via EIP-712 bundles, so **our executor contributes nothing to the win condition.** Good hedge, bad reason to keep the contract.
+
+### Why #1 is the call
+
+**Long-tail / fresh-launch V2-fork backrunning** is the only strategy that satisfies all three conditions at once:
+
+1. **It is genuinely under-contested in 2026.** Competition on the true long tail is documented as roughly *two orders of magnitude lighter* than mainstream liquidity. There is no Priority Gas Auction on a pool the top 2-3 spam-bots per chain don't bother to model. The edge is **breadth and freshness of pool coverage**, which is a software problem a small team can win — not a nanosecond co-location problem it can't.
+
+2. **It makes our existing, paid-for asset the correct tool.** V2-fork-only is a *feature* here — the long tail *is* V2 forks (Base memecoin flow, BNB four.meme / Binance Alpha launches, PancakeSwap-V2 forks fragmented across ~10 networks). Atomicity gives exactly the revert-protection these risky pools demand. We strip the dead code and trim gas, but we **reuse** the core, we don't discard it.
+
+3. **The off-chain moat is buildable by us.** Fast `PairCreated`/`Sync` discovery across many forks + a multi-hop cyclic solver over live reserves + private inclusion (48 Club / bloXroute on BSC, private RPC on Base) is real engineering, not capital or latency arms-racing.
+
+**The honest downside of #1, stated up front:** profits are *small and lumpy* (tens to low-hundreds of dollars per trade), partly eaten by gas + inclusion bribe. The realistic outcome is a **modest, irregular income stream on the team's own capital — not a fund.** And the single make-or-break risk is **adverse selection / honeypots**: long-tail pools are riddled with transfer-tax, blacklist, rug, and fake-reserve tokens. A backrun that buys an unsellable token is a 100% loss. A robust token-safety / `eth_call` revert-guard simulation layer is **mandatory** and is the make-or-break, not a nice-to-have.
+
+**#2 (Auction/OEV) is the explicit hedge.** If the long-tail edge proves too thin, OEV backrunning (especially Polygon FastLane-Atlas, which has a smaller ~17-searcher pool and is more open than SVR) is the fallback. But choosing #2 means **accepting the executor as sunk cost** — so we only pivot there if #1 fails its kill-criteria.
+
+---
+
+## 4. The research system
+
+We scaffolded a read-only off-chain pipeline in a new top-level **`research/`** directory (independent of `contracts/`). Its single job: answer **one question on real data** —
+
+> *On our target thin/under-contested chains, do round-trip baseToken cycles across V2-fork pools clear a profit AFTER gas, priority fee, slippage, and a realistic win-rate haircut — often enough and large enough to matter?*
+
+If yes → strip and audit the contract. If no → kill the project before audit spend. The contract stays untouched and unaudited until this pipeline returns GO.
+
+### What's scaffolded (and what's honestly still a TODO)
+
+All files pass `node --check`; the offline demo runs end-to-end (`node research/run.js --demo`).
+
+| File | Stage | Real now | Honestly TODO |
+|---|---|---|---|
+| `research/README.md` | — | Panel verdict, methodology, per-stage table, run/ops notes | — |
+| `research/config.example.json` | — | Target chains (BSC on; Base/Polygon stubbed), RPC env-var names, per-fork factories + **per-fork feeBps**, Multicall3, base tokens, scan/pathfinder/gas/kill params | — |
+| `research/config.js` | — | Dependency-light loader; resolves RPCs from env only; warns on factory drift | — |
+| `research/scanner.js` | 1 | **Real** `getReserves()`/`token0()`/`token1()` + factory `allPairsLength()` probe; writes versioned pool snapshot; `seedPairs` fast-path | Full `PairCreated` replay / `allPairs(i)` + Multicall3 enumeration; **on-chain per-fork fee verification** |
+| `research/pathfinder.js` | 2 | **Real** directed token graph (weight `= -ln(fee-adjusted rate)`), Bellman-Ford negative-cycle detection anchored at baseToken, 2-5 hop candidates | — (correctly documented as **candidate generator only** — cannot net absolute gas) |
+| `research/backtester.js` | 3+4 | **Real** optimal-input sizing (geometric grid + ternary refine over BigInt CPMM), net-of-gas PnL priced for **both** the fat `BofhContractV2` and a lean Huff target, explicit `applyKillCriteria` → KILL / GO(PROVISIONAL) | **revm/Anvil re-simulation** against real historical state; **live-shadow win/revert-rate** measurement |
+| `research/gasModel.js` | 3 | Per-hop gas constants for fat-vs-lean executors, effective gas price incl. priority/bribe, `compareExecutors` helper | Constants are **clearly-marked PLACEHOLDERS** — must be measured |
+
+Two real bugs were found and fixed during smoke-testing, which is exactly why we build this before trusting any number:
+
+1. A Bellman-Ford early-break that conflated *convergence* with *absence of a negative cycle* → rewritten to standard V-1 relaxation passes + a separate detection pass.
+2. A degenerate optimal-input search on a *linear* grid that missed the true optimum → rewritten to a geometric/log-spaced grid + ternary refine.
+
+### The kill-criteria methodology
+
+The pipeline is **kill-criteria-driven**, not demo-driven. It runs in two modes:
+
+- **(A) Historical backtest** — sweep N blocks of real history (archive node = ground truth), reconstruct reserves per block, find + size + simulate cycles, record net PnL *assuming you'd have landed the tx*, then apply a realistic win-rate/latency haircut.
+- **(B) Live shadow** — run the live scanner for weeks **signing nothing**, log every opportunity it *would* have taken, then inspect the next block to see whether a competitor took it (you lost the race) or it would have reverted.
+
+It reports: **net profit/opportunity, opportunities/day, gross-vs-net spread, win-rate, revert rate, capital-at-risk, Sharpe.**
+
+**KILL the project if, on the best target chain over a representative window, ANY of:**
+
+1. Median **net-of-gas profit/opportunity < 2-3× total frictions** (fees + gas + bribe).
+2. Realistic **win-rate so low that expected daily net < infra + capital cost.**
+3. The edge exists **only for a lean Huff executor**, never for a realistic executor at our gas profile — meaning we'd have to win the rewrite arms race just to break even.
+4. **Revert/loss rate** lands in the bad regime (the literature shows 5-40% daily revert on fast-finality rollups; honeypots compound this) and wipes expected value.
+
+**Backtesting hygiene (non-negotiable, baked into the harness):** model **2× historical spread as slippage**; add latency; expect **live drawdown 1.5-2× backtest** and **live Sharpe ~1 point lower** than backtest. **Treat a backtest Sharpe > 3 as overfitting, not success.** The archive-node ground truth + revm re-simulation exist specifically to kill look-ahead and state-staleness bias — the two failure modes that make a backtest lie in our favor.
+
+### Stack and sequencing
+
+- **Stage 0 (data plane):** self-host a Reth/Erigon archive node per target chain as the single source of truth so backtest and live read byte-identical state; commercial RPC (QuickNode/Alchemy/Chainstack/Dwellir) only as fallback/bootstrap. Batch reads via Multicall3.
+- **Language:** Python (`web3.py`, the existing `bofh/` package) for the scanner / registry / path-finder prototype / kill-criteria notebooks; **Rust (Alloy + revm)** only for the proven hot loop (the microsecond simulator). Don't port to Rust until Python proves the loop is worth porting.
+- **Storage:** Postgres or Parquet for the pool registry + opportunity log; pandas/Jupyter for the report.
+
+---
+
+## 5. Decision gates
+
+The sequencing is fixed and must not be reordered:
+
+```
+  PROVE the off-chain edge  →  STRIP the contract  →  AUDIT last
+  (research/ on real data)     (dead code, gas)       (only on GREEN)
+```
+
+We do not strip the contract for production until the edge is proven. We do not pay for an audit until the contract is stripped *and* the edge is proven. Spending audit money on an unproven strategy is lighting money on fire to certify a commodity.
+
+### GO → greenlight stripping, then audit
+
+Proceed only when **all** hold on the best target chain over a representative window:
+
+- Median net-of-gas profit/opportunity **≥ 2-3× total frictions**, sustained.
+- Live-shadow **win-rate × opportunities/day** yields **expected daily net > infra + capital cost** with margin.
+- Profitable at a **realistic (not Huff-only) executor gas profile** — i.e., a modest gas trim makes it work; we don't need to win a Huff arms race to break even.
+- **Revert/honeypot loss rate** controlled by the token-safety guard to a level that doesn't wipe EV.
+- Backtest survives the hygiene haircuts (2× slippage, latency, live-Sharpe −1) and is **not** in the Sharpe>3 overfit zone.
+
+Then, and only then: strip `BofhContractV2` for production (remove the now-unused `ExcessiveSlippage` from the interface, finish removing the historical golden-ratio doc body, trim gas, evaluate adding flash loans *only if the data says capital-holding is the binding constraint*), and **audit last** on the stripped, proven configuration.
+
+### KILL → sunset
+
+Trigger a sunset if any single KILL criterion from §4 fires and cannot be remedied within the research window:
+
+- Net edge below the friction multiple, or
+- Win-rate too low for positive expected daily net, or
+- Edge is Huff-only at our realizable gas profile, or
+- Revert/honeypot losses dominate.
+
+A KILL is **not** a failure of the team — it is the research system doing its job *before* we spent on an audit. The contract code (now honest and tested) remains a clean reusable artifact; the conclusion is simply that the off-chain edge isn't there at a size that matters, and we stop.
+
+**One caveat on the GO bar:** win-rate is impossible to estimate perfectly without actually racing. If live-shadow looks green but win-rate is the only uncertain input, a **tiny real-capital pilot** (smallest sizes, a handful of trades) to confirm landing rate is acceptable *before* committing to a full GO and an audit — but that pilot is the most we spend until the number is confirmed.
+
+---
+
+## 6. Immediate next 2 weeks
+
+Ordered. Do them in this sequence.
+
+1. **Pick the single target chain and base token.** Default to **BSC** (already enabled in `research/config.example.json`; thin four.meme / Binance Alpha long-tail flow; 48 Club / bloXroute private inclusion available). Set `enabled: true`, copy to `research/config.json` (gitignored), and confirm WBNB as base token.
+2. **Stand up the data plane (Stage 0).** Bootstrap on a commercial archive RPC (QuickNode/Chainstack/Dwellir) to start *today*; in parallel begin provisioning a self-hosted Reth/Erigon archive box. Export the `RESEARCH_RPC_*` env vars. Verify the scanner's `allPairsLength()` probe connects.
+3. **Finish Stage 1 pair enumeration + per-fork fee verification.** Replace the `seedPairs` fast-path with real `PairCreated` replay (or `allPairs(i)` backfill) + Multicall3 batched `getReserves`. **Read each fork's fee on-chain — do not hardcode** (the `fee=3` bug in the old mock script is exactly what produces phantom profit). Persist the pool registry.
+4. **Wire revm/Anvil re-simulation into `backtester.js` (Stage 3).** This is the most load-bearing TODO: without it, pure-formula CPMM overstates profit and silently ignores reverts and honeypots. Re-simulate each candidate path against real historical state.
+5. **Build the token-safety / honeypot guard.** An `eth_call` buy-then-sell revert-simulation that rejects transfer-tax, blacklist, fake-reserve, and unsellable tokens. This is the make-or-break risk for #1 — treat it as a first-class component, not a filter.
+6. **Measure real gas constants** for `BofhContractV2` (via `REPORT_GAS`) and for a lean Huff/Yul reference, and load them into `gasModel.js` to replace the placeholders. This is what makes the "Huff-only edge?" kill-criterion real.
+7. **Run a 2-4 week historical backtest, then start the live-shadow window.** Sign nothing. Log every would-be opportunity; check the next block for competitor capture and reverts. Produce the kill-criteria report (net profit/opp, opps/day, win-rate, revert rate, Sharpe) in a pandas/Jupyter notebook.
+8. **Convene a GO/KILL decision review at the end of week 2** against the §5 gates. Default posture: **KILL unless the data clears the GO bar.** The burden of proof is on the edge, not on the skeptic.
+
+**What we explicitly do NOT do in the next two weeks:** touch the audited-readiness of the contract, pay for an audit, add flash loans, rewrite in Huff, or build the Base/Polygon legs. None of that is justified until the BSC long-tail edge is proven on real data.

--- a/research/.gitignore
+++ b/research/.gitignore
@@ -1,0 +1,8 @@
+# Local research config holds RPC endpoints — never commit it. Use config.example.json
+# as the committed template and keep your filled-in copy here, ignored.
+config.json
+
+# Pool snapshots, opportunity logs, and any recorded chain data the pipeline writes.
+data/
+*.snapshot.json
+snapshot.*.json

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,151 @@
+# BofhContract — Off-Chain Research & Backtest Toolkit (`research/`)
+
+> **Status: starter skeleton.** Real RPC enumeration and revm re-simulation are TODO'd.
+> Everything compiles (`node --check`) and the offline Stage 2→4 pipeline runs today via
+> `node research/run.js --demo`. This directory is **independent of `contracts/` and
+> `test/`** and touches neither.
+
+## Why this exists (read before writing any more contract code)
+
+A 6-expert panel reviewed BofhContractV2 and concluded:
+
+- As a **competitive arbitrage tool it does not make sense** today — it is ~2–3× the gas of
+  a lean Huff/Yul executor, V2-only, has no flash loans, and forces you to hold capital.
+- Its advertised **"golden ratio optimization" is dead code** (zero production callers; only
+  test mocks invoke it).
+- The real money-making edge is **off-chain** (fast pool discovery + a real cyclic
+  path-finder + private inclusion), and **none of it exists in this repo**:
+  `scripts/find-arbitrage.js` is a Hardhat **mock-pool demo** that fabricates reserves and
+  loops `executeSwap` over hardcoded paths.
+
+The verdict: **REFOCUS** to a non-custodial, multi-V2-fork atomic executor for the team's
+own capital on **thin / under-contested EVM chains** — but **PROVE the off-chain edge on
+real chain data FIRST**, then strip the contract, and **audit LAST**.
+
+This toolkit is Step 1: the read-only off-chain pipeline that answers one question on real
+data, **before any audit spend**:
+
+> On our target thin/under-contested chains, do round-trip baseToken arbitrage cycles across
+> V2-fork pools clear a profit **after gas, priority fee/bribe, slippage, and a realistic
+> win-rate haircut** — often enough and large enough to matter?
+
+If **yes** → strip + audit the contract. If **no** → **kill the project before spending on
+an audit.**
+
+## Kill-criteria-driven methodology
+
+The whole pipeline is a gate, not a product. We never assume an edge; we make a `GO` hard to
+earn. The decision lives in `backtester.js::applyKillCriteria` and the thresholds in
+`config.*.json → kill`:
+
+A run is **KILL** if **any** of these trip:
+
+1. **Margin too thin** — median net-of-gas profit per profitable op `< minNetProfitToFrictionRatio ×` friction.
+2. **Sub-economic** — expected daily net (`ops/day × median net × realistic win-rate`) `< infraCostUsdPerDay`.
+3. **Only a lean executor profits** — if **no** opportunity is profitable with the fat
+   `BofhContractV2` but some are profitable with a lean Huff target, that is a signal to
+   **strip/rewrite the contract**, not to proceed with the current one.
+4. **Reverts dominate** — measured revert rate `> maxAcceptableRevertRate` (enforced only once
+   revm/Anvil re-simulation is wired; until then the report prints a provisional-`GO` warning).
+0. **Not representative** — fewer than `minOpportunitiesPerDay` profitable ops/day.
+
+A `GO` is always **PROVISIONAL** until (a) revm re-simulation measures reverts/honeypots and
+(b) a live-shadow window measures a real win-rate. Backtest hygiene to apply before trusting
+any green: model ~2× historical spread as slippage, expect live drawdown 1.5–2× backtest, and
+treat a backtest Sharpe > 3 as overfitting rather than success.
+
+**Sequencing (matches the panel): prove the off-chain edge here → only then strip the contract → audit last.**
+
+## Pipeline stages
+
+| Stage | File | What it does | Real vs TODO |
+|------|------|--------------|--------------|
+| 0 Data plane | *(external)* | Self-host a Reth/Erigon archive node per chain so live + historical reads are byte-identical; commercial RPC only as fallback. | TODO (ops): see below. |
+| 1 Scanner | `scanner.js` | Enumerate V2-fork pairs per factory, snapshot reserves + **per-fork** fee to a JSON pool snapshot. | `getReserves()/token0()/token1()` are **real** ethers v6 calls. Full enumeration (PairCreated replay / `allPairs(i)` + Multicall3) is **TODO**. |
+| 2 Path-finder | `pathfinder.js` | Build the token graph, run Bellman-Ford **negative-cycle** detection seeded at baseToken to surface round-trip candidates (2–5 hops). **Pure function over a snapshot** → testable offline. | Real, working candidate generator. Exhaustive enumeration (Johnson / line-graph MMBF) is a noted upgrade. |
+| 3 Sizing + net-of-gas | `backtester.js` | Size each cycle to its optimal input, simulate CPMM output, subtract per-hop fees **and** gas+priority fee priced for **both** the fat and lean executors. | Real CPMM math. **revm/Anvil re-simulation against historical state is TODO** (without it, pure formulas overstate profit). |
+| 4 Paper-trade + KILL/GO | `backtester.js` | Apply explicit kill-criteria, emit the verdict + stats. | Real. Win-rate/revert come from config until live-shadow + revm provide measured values. |
+| — Gas model | `gasModel.js` | Documented per-hop gas constants for **this** executor vs a **lean** target so the strip decision is data-driven. | Constants are **PLACEHOLDERS** — replace with measured `REPORT_GAS` numbers. |
+| — Config | `config.js` | Loads config, resolves RPC from **env vars only**, reuses `scripts/utils/addresses.js` for base tokens/factories, warns on address drift. | Real. |
+| — Runner | `run.js` | Offline orchestrator: runs Stage 2→4 over an existing/`--demo` snapshot with zero RPC. | Real. |
+
+## Configure
+
+1. Copy the example config and keep your real one out of git:
+
+   ```bash
+   cp research/config.example.json research/config.json   # config.json is gitignored
+   ```
+
+2. **RPC URLs are read from environment variables, never from the JSON.** Each chain entry
+   names its env vars (`rpcEnv`, `rpcFallbackEnv`, `wsEnv`). Export them:
+
+   ```bash
+   export RESEARCH_RPC_BSC="https://your-bsc-archive-endpoint"
+   export RESEARCH_RPC_BSC_FALLBACK="https://commercial-rpc-fallback"   # optional
+   export RESEARCH_WS_BSC="wss://your-bsc-ws-endpoint"                  # optional, for live newHeads
+   ```
+
+3. Enable the chain(s) you want (`"enabled": true`) and tune `scan`, `pathfinder`, `gas`,
+   and `kill`. Factory addresses mirror `scripts/utils/addresses.js`; `config.js` **warns on
+   drift** so the canonical book stays the source of truth. Per-fork fees (`feeBps`) MUST be
+   correct per DEX (PancakeV2 = 25, Biswap = 10, ApeSwap = 20, Uni/Sushi/Quick = 30) — do not
+   hardcode one fee across forks (the bug in the old mock).
+
+### Stage 0 (data plane) — operational TODO
+
+For trustworthy backtests, stand up a **Reth or Erigon archive node** per target chain
+(NVMe box, ~1.6TB+) so historical `getReserves` at any block and live `newHeads` come from
+identical state. Use QuickNode/Alchemy/Chainstack/Dwellir only to bootstrap. Batch reads via
+**Multicall3** (`0xcA11bde05977b3631167028862bE2a173976CA11`, already in the config). This
+step has no code here on purpose — it is infra.
+
+## Run each stage
+
+```bash
+# Offline smoke test (no RPC needed): runs path-finder + backtester over a synthetic snapshot
+node research/run.js --demo
+
+# Stage 1: scan configured chains -> writes research/data/snapshot.<chain>.json
+#   (needs RPC env vars + "seedPairs" in config until full enumeration is implemented)
+node research/scanner.js
+
+# Stage 2-4: replay an existing snapshot through path-finder + backtester
+node research/run.js research/data/snapshot.bsc.json
+
+# Syntax-check everything
+for f in research/*.js; do node --check "$f"; done
+```
+
+### What `--demo` shows
+
+The demo builds a 3-pool synthetic snapshot with a deliberate ~2.75% triangular edge. The
+path-finder finds the `BASE→A→B→BASE` cycle, the backtester sizes it (~4.5 base in → ~$36
+net after gas, profitable for **both** executors), and the verdict is **KILL** — correctly —
+because a single opportunity fails the representativeness gates (`< 5 ops/day`, daily net `<`
+infra cost). That is the harness doing its job: an edge has to be *broad and repeatable*, not
+just *present once*.
+
+## Definite next steps (to turn the skeleton into a real prover)
+
+1. **Stage 1 enumeration** — replay `PairCreated` logs per factory (gives creation block =
+   freshness signal) or `allPairsLength()` + `allPairs(i)` backfill; batch `getReserves` via
+   Multicall3; persist to Postgres/Parquet; **verify each fork's fee on-chain**.
+2. **Stage 3 ground truth** — re-simulate each candidate path against **real historical state
+   with revm/Anvil** to catch reverts, rounding, fee-on-transfer/honeypot tokens. This is the
+   single most important fidelity upgrade; pure CPMM math lies.
+3. **Gas constants** — replace the `gasModel.js` placeholders with measured numbers
+   (`REPORT_GAS=true npx hardhat test` for `bofhV2`; a public Huff/Yul benchmark for the lean
+   target).
+4. **Live-shadow mode** — run the scanner for weeks signing **nothing**, log every would-be
+   op, inspect the next block to see if a competitor took it / it would have reverted →
+   measures the real **win-rate** and **revert rate** that the kill-criteria need.
+5. **Token-safety layer** — `eth_call` revert-guard + honeypot/transfer-tax heuristics before
+   any path is counted profitable (long-tail pools are full of unsellable tokens).
+
+## What this toolkit deliberately is NOT
+
+- Not a live trading bot — it **signs nothing**.
+- Not a contract change — `contracts/` and `test/` are untouched and stay unaudited until
+  Stage 4 returns a real `GO`.
+- Not a finished product — the honest TODOs above are where real data/work is required.

--- a/research/backtester.js
+++ b/research/backtester.js
@@ -1,0 +1,326 @@
+'use strict';
+
+/**
+ * Stage 3 + Stage 4 — net-of-gas profit simulator and KILL/GO paper-trade harness.
+ *
+ * Consumes: a snapshot (scanner.js) + candidate cycles (pathfinder.js) + the gas model
+ * (gasModel.js) + config thresholds. Produces a paper-trade report that decides GO vs KILL
+ * BEFORE any audit spend.
+ *
+ * WHAT IS REAL HERE:
+ *  - Per-hop CPMM output and the closed-form-ish optimal-size SEARCH are real math over the
+ *    snapshot reserves (pure, offline, testable).
+ *  - Net PnL subtracts per-hop fees (already in getAmountOut) AND gas+priority fee from the
+ *    gas model, priced for BOTH the fat bofhV2 executor and the lean Huff target.
+ *
+ * WHAT IS HONESTLY MISSING (TODO before trusting a GO):
+ *  - revm/Anvil re-simulation against real historical state to catch reverts, rounding,
+ *    fee-on-transfer/honeypot tokens. A pure CPMM formula WILL overstate profit.
+ *  - A real win-rate measured by LIVE SHADOW mode (log would-be ops, inspect next block to
+ *    see if a competitor took it / it reverted). Here win-rate is a config assumption.
+ *  - USD pricing of the base token leg beyond the native-token proxy.
+ *
+ * The kill-criteria are deliberately strict and explicit so a GO is earned, not assumed.
+ */
+
+const { getAmountOut } = require('./pathfinder.js');
+const { gasCostForCycle, compareExecutors } = require('./gasModel.js');
+
+/**
+ * Simulate a full round-trip cycle for a given input amount.
+ * @param {bigint} amountIn - base-token amount in (wei).
+ * @param {Array<object>} hops - per-hop edges from the pathfinder (reserveIn/reserveOut/feeBps).
+ * @returns {bigint} final base-token amount out (wei) after all hops.
+ */
+function simulateCycle(amountIn, hops) {
+  let amt = amountIn;
+  for (const h of hops) {
+    amt = getAmountOut(amt, BigInt(h.reserveIn), BigInt(h.reserveOut), h.feeBps);
+    if (amt <= 0n) return 0n;
+  }
+  return amt;
+}
+
+/**
+ * Find a near-optimal input size by golden-section-free coarse+refine search.
+ * (A closed-form optimum exists for 2-pool cycles and is extendable hop-by-hop — TODO to
+ * implement exactly; this bounded search is robust for the skeleton and >2 hops.)
+ *
+ * Profit(x) = simulateCycle(x) - x is unimodal in x for CPMM cycles, so a ternary/grid
+ * search converges. We grid-search in log space then refine around the best point.
+ *
+ * @param {Array<object>} hops
+ * @param {{ maxInputWei?: bigint }} [opts]
+ * @returns {{ amountIn: bigint, amountOut: bigint, grossProfitWei: bigint }}
+ */
+function optimalInput(hops, opts = {}) {
+  if (!hops || hops.length === 0) return { amountIn: 0n, amountOut: 0n, grossProfitWei: 0n };
+
+  // Upper bound: a fraction of the smallest base-side reserve on the first hop keeps us in
+  // the regime where the cycle can be profitable (huge size always self-destructs via impact).
+  const firstReserveIn = BigInt(hops[0].reserveIn);
+  // Cap the search at the first hop's base-side reserve: trading more than the pool holds
+  // is always self-defeating (price impact dominates). The true optimum is typically a
+  // small fraction of this, so the grid below is GEOMETRIC (log-spaced) to sample the
+  // profitable low region densely instead of wasting points on the deep-negative high end.
+  const hardCap = opts.maxInputWei || firstReserveIn;
+  if (hardCap <= 0n) return { amountIn: 0n, amountOut: 0n, grossProfitWei: 0n };
+
+  const profitAt = (x) => {
+    if (x <= 0n) return -1n;
+    const out = simulateCycle(x, hops);
+    return out - x;
+  };
+
+  // Geometric grid over [lo, hardCap]: x_i = lo * (hardCap/lo)^(i/steps). Profit(x) is
+  // unimodal for a CPMM cycle, so the grid brackets the optimum; we refine with ternary.
+  const lo = hardCap / 100000000n > 0n ? hardCap / 100000000n : 1n;
+  const steps = 80;
+  const loF = Number(lo);
+  const ratio = Number(hardCap) / loF; // hardCap/lo as a float for exponent spacing
+  let best = { amountIn: lo, profit: profitAt(lo) };
+  for (let i = 1; i <= steps; i++) {
+    const xF = loF * Math.pow(ratio, i / steps);
+    const x = BigInt(Math.max(1, Math.round(xF)));
+    const p = profitAt(x);
+    if (p > best.profit) best = { amountIn: x, profit: p };
+  }
+
+  // Ternary refine in the bracket [best/4, best*4] (clamped), where Profit is unimodal.
+  let left = best.amountIn / 4n > 0n ? best.amountIn / 4n : 1n;
+  let right = best.amountIn * 4n < hardCap ? best.amountIn * 4n : hardCap;
+  for (let iter = 0; iter < 200 && right - left > 1n; iter++) {
+    const third = (right - left) / 3n;
+    const m1 = left + third;
+    const m2 = right - third;
+    if (profitAt(m1) < profitAt(m2)) {
+      left = m1 + 1n;
+    } else {
+      right = m2;
+    }
+  }
+  // Pick the best of {grid winner, refined endpoints}.
+  const candidatesX = [best.amountIn, left, right];
+  let xStar = candidatesX[0];
+  let pStar = profitAt(xStar);
+  for (const x of candidatesX.slice(1)) {
+    const p = profitAt(x);
+    if (p > pStar) {
+      pStar = p;
+      xStar = x;
+    }
+  }
+  const outStar = simulateCycle(xStar, hops);
+  return { amountIn: xStar, amountOut: outStar, grossProfitWei: outStar - xStar };
+}
+
+/**
+ * Convert a wei base-token amount to USD using the native-token USD price as a proxy.
+ * (TODO: real per-token USD; for a wrapped-native base token this proxy is exact.)
+ * @param {bigint} wei
+ * @param {number} nativeUsdPrice
+ * @returns {number}
+ */
+function weiToUsd(wei, nativeUsdPrice) {
+  return (Number(wei) / 1e18) * Number(nativeUsdPrice || 0);
+}
+
+/**
+ * Evaluate a single candidate cycle: size it, simulate, and net out gas for BOTH executors.
+ * @param {object} candidate - { tokens, hops, marginalEdgePct }.
+ * @param {object} gasCfg - config.gas.
+ * @returns {object} evaluation record.
+ */
+function evaluateCandidate(candidate, gasCfg) {
+  const hops = candidate.hops;
+  const hopCount = hops.length;
+  const sized = optimalInput(hops);
+
+  const grossUsd = weiToUsd(sized.grossProfitWei, gasCfg.nativeUsdPrice);
+  const gasFat = gasCostForCycle(hopCount, gasCfg, 'bofhV2');
+  const gasLean = gasCostForCycle(hopCount, gasCfg, 'leanHuff');
+
+  const netUsdFat = grossUsd - gasFat.costUsd;
+  const netUsdLean = grossUsd - gasLean.costUsd;
+
+  return {
+    tokens: candidate.tokens,
+    hopCount,
+    marginalEdgePct: candidate.marginalEdgePct,
+    amountInWei: sized.amountIn.toString(),
+    amountOutWei: sized.amountOut.toString(),
+    grossProfitWei: sized.grossProfitWei.toString(),
+    grossUsd,
+    gasUsdFat: gasFat.costUsd,
+    gasUsdLean: gasLean.costUsd,
+    netUsdFat,
+    netUsdLean,
+    // Friction = gas (the dominant landing cost in this skeleton). priority fee already in gas.
+    frictionUsd: gasFat.costUsd,
+    profitableFat: netUsdFat > 0,
+    profitableLean: netUsdLean > 0,
+    onlyLeanProfitable: netUsdLean > 0 && netUsdFat <= 0
+  };
+}
+
+/**
+ * Apply explicit KILL/GO criteria to an evaluated batch and produce the verdict.
+ *
+ * KILL if ANY of:
+ *  (1) median net-of-gas profit per profitable opportunity (fat executor) < ratio x friction;
+ *  (2) realistic win-rate so low that expected daily net < infra cost;
+ *  (3) the edge exists ONLY for the lean executor (fat contract never lands profitably);
+ *  (4) [TODO when revm wired] revert rate exceeds maxAcceptableRevertRate.
+ * GO only if none trip and there is a representative opportunity count.
+ *
+ * @param {object[]} evals - evaluateCandidate() records.
+ * @param {object} killCfg - config.kill.
+ * @param {{ windowDays?: number, revertRate?: number }} [obs] - observed run stats.
+ * @returns {object} verdict report.
+ */
+function applyKillCriteria(evals, killCfg, obs = {}) {
+  const reasons = [];
+  const windowDays = obs.windowDays || 1;
+
+  const profitableFat = evals.filter((e) => e.profitableFat);
+  const profitableLean = evals.filter((e) => e.profitableLean);
+
+  const netsFat = profitableFat.map((e) => e.netUsdFat).sort((a, b) => a - b);
+  const medianNetFat = netsFat.length ? netsFat[Math.floor(netsFat.length / 2)] : 0;
+  const medianFriction =
+    evals.length
+      ? evals.map((e) => e.frictionUsd).sort((a, b) => a - b)[Math.floor(evals.length / 2)]
+      : 0;
+
+  const opportunitiesPerDay = profitableFat.length / windowDays;
+  const winRate = typeof killCfg.minWinRate === 'number' ? (obs.winRate ?? killCfg.minWinRate) : 1;
+  const expectedDailyNetUsd = opportunitiesPerDay * medianNetFat * winRate;
+
+  // (1) profit-to-friction ratio
+  const ratio = killCfg.minNetProfitToFrictionRatio || 2.5;
+  if (medianFriction > 0 && medianNetFat < ratio * medianFriction) {
+    reasons.push(
+      `KILL(1): median net profit/op $${medianNetFat.toFixed(4)} < ${ratio}x friction ` +
+        `$${(ratio * medianFriction).toFixed(4)}.`
+    );
+  }
+
+  // (2) daily expected net below infra cost
+  const infra = killCfg.infraCostUsdPerDay || 0;
+  if (expectedDailyNetUsd < infra) {
+    reasons.push(
+      `KILL(2): expected daily net $${expectedDailyNetUsd.toFixed(2)} < infra cost ` +
+        `$${infra.toFixed(2)} (winRate=${winRate}).`
+    );
+  }
+
+  // (3) edge only for lean executor
+  if (profitableFat.length === 0 && profitableLean.length > 0) {
+    reasons.push(
+      `KILL(3): NO opportunity is profitable with the fat BofhContractV2; ` +
+        `${profitableLean.length} are profitable ONLY with a lean Huff executor. ` +
+        'Strip+rewrite the contract before proceeding.'
+    );
+  }
+
+  // (4) revert rate (only enforced once revm is wired and obs.revertRate provided)
+  if (typeof obs.revertRate === 'number') {
+    const maxRevert = killCfg.maxAcceptableRevertRate ?? 0.3;
+    if (obs.revertRate > maxRevert) {
+      reasons.push(
+        `KILL(4): revert rate ${(obs.revertRate * 100).toFixed(1)}% > ` +
+          `${(maxRevert * 100).toFixed(1)}% threshold.`
+      );
+    }
+  } else {
+    reasons.push(
+      'WARN: revert rate NOT measured (revm/Anvil re-simulation TODO). A GO here is ' +
+        'provisional — pure CPMM math omits reverts/honeypots and overstates profit.'
+    );
+  }
+
+  // Representativeness gate
+  if (opportunitiesPerDay < (killCfg.minOpportunitiesPerDay || 0)) {
+    reasons.push(
+      `KILL(0): only ${opportunitiesPerDay.toFixed(2)} profitable ops/day < ` +
+        `${killCfg.minOpportunitiesPerDay} required to be a real income stream.`
+    );
+  }
+
+  const hardKills = reasons.filter((r) => r.startsWith('KILL'));
+  const verdict = hardKills.length === 0 ? 'GO (PROVISIONAL)' : 'KILL';
+
+  return {
+    verdict,
+    reasons,
+    stats: {
+      candidates: evals.length,
+      profitableFat: profitableFat.length,
+      profitableLean: profitableLean.length,
+      medianNetUsdFat: medianNetFat,
+      medianFrictionUsd: medianFriction,
+      opportunitiesPerDay,
+      assumedWinRate: winRate,
+      expectedDailyNetUsd
+    }
+  };
+}
+
+/**
+ * Full Stage 3+4 run over a snapshot + candidates. Pure (no I/O) so it is unit-testable.
+ * @param {object} snapshot
+ * @param {object[]} candidates - from pathfinder.findCandidateCycles().
+ * @param {object} config - full research config (uses .gas and .kill).
+ * @param {{ windowDays?: number, winRate?: number, revertRate?: number }} [obs]
+ * @returns {{ evals: object[], report: object, executorComparisonSample: object }}
+ */
+function runBacktest(snapshot, candidates, config, obs = {}) {
+  const gasCfg = config.gas || {};
+  const killCfg = config.kill || {};
+  const evals = candidates.map((c) => evaluateCandidate(c, gasCfg));
+  const report = applyKillCriteria(evals, killCfg, obs);
+  // Head-to-head fat-vs-lean gas at a representative hop count, for the strip decision.
+  const sampleHops = evals.length ? evals[0].hopCount : 3;
+  const executorComparisonSample = compareExecutors(sampleHops, gasCfg);
+  return { evals, report, executorComparisonSample };
+}
+
+/**
+ * Pretty-print a paper-trade report to stdout. Returns the same object for chaining.
+ * @param {{ evals: object[], report: object, executorComparisonSample: object }} result
+ * @returns {object}
+ */
+function printReport(result) {
+  const { evals, report, executorComparisonSample } = result;
+  const line = '='.repeat(72);
+  console.log(`\n${line}\nPAPER-TRADE REPORT (net-of-gas) — Stage 4 KILL/GO\n${line}`);
+  console.log(`candidates evaluated : ${report.stats.candidates}`);
+  console.log(`profitable (fat V2)  : ${report.stats.profitableFat}`);
+  console.log(`profitable (lean)    : ${report.stats.profitableLean}`);
+  console.log(`median net/op (fat)  : $${report.stats.medianNetUsdFat.toFixed(4)}`);
+  console.log(`median friction/op   : $${report.stats.medianFrictionUsd.toFixed(4)}`);
+  console.log(`opportunities/day    : ${report.stats.opportunitiesPerDay.toFixed(2)}`);
+  console.log(`assumed win-rate     : ${report.stats.assumedWinRate}`);
+  console.log(`expected daily net   : $${report.stats.expectedDailyNetUsd.toFixed(2)}`);
+  console.log(
+    `gas fat vs lean (${executorComparisonSample.bofhV2.executor === 'bofhV2' ? '' : ''}sample` +
+      ` ${evals.length ? evals[0].hopCount : 3} hops): ` +
+      `fat $${executorComparisonSample.bofhV2.costUsd.toFixed(4)} vs ` +
+      `lean $${executorComparisonSample.leanHuff.costUsd.toFixed(4)} ` +
+      `(overhead $${executorComparisonSample.overheadUsd.toFixed(4)}/op)`
+  );
+  console.log(`\nVERDICT: ${report.verdict}`);
+  for (const r of report.reasons) console.log(`  - ${r}`);
+  console.log(line + '\n');
+  return result;
+}
+
+module.exports = {
+  simulateCycle,
+  optimalInput,
+  weiToUsd,
+  evaluateCandidate,
+  applyKillCriteria,
+  runBacktest,
+  printReport
+};

--- a/research/config.example.json
+++ b/research/config.example.json
@@ -1,0 +1,96 @@
+{
+  "_comment": [
+    "Copy to research/config.json (gitignored) and fill in real RPCs.",
+    "RPC URLs are read from environment variables named by `rpcEnv` so secrets never",
+    "land in git. Factory addresses are intentionally duplicated from",
+    "scripts/utils/addresses.js so the research toolkit stays runnable without loading",
+    "the Hardhat runtime; keep them in sync (research/config.js re-exports the canonical",
+    "list from addresses.js and will WARN if this file drifts).",
+    "",
+    "TARGET-CHAIN RATIONALE (see README): the edge only survives on thin / soft-",
+    "competition chains. Mainstream Ethereum L1 and contested L2s are excluded on",
+    "purpose. Start with whichever of these has the cheapest archive access for you."
+  ],
+
+  "baseTokenSymbol": "wrappedNative",
+
+  "scan": {
+    "_comment": "Stage-1 scanner knobs. Real enumeration is TODO; these gate the skeleton.",
+    "maxPairsPerFactory": 2000,
+    "reserveBatchSize": 100,
+    "minReserveBaseToken": "1.0",
+    "snapshotBlockTag": "latest",
+    "snapshotOutPath": "research/data/snapshot.latest.json"
+  },
+
+  "pathfinder": {
+    "_comment": "Stage-2 negative-cycle search knobs. Mirrors contract MAX_PATH_LENGTH=5.",
+    "maxHops": 5,
+    "minHops": 2,
+    "minEdgeReserveBaseToken": "1.0",
+    "topN": 50
+  },
+
+  "gas": {
+    "_comment": "Stage-3/4 cost model. priorityFeeGwei + baseFeeGwei feed gasModel.js.",
+    "baseFeeGwei": 1.0,
+    "priorityFeeGwei": 1.0,
+    "nativeUsdPrice": 600.0,
+    "executor": "bofhV2"
+  },
+
+  "kill": {
+    "_comment": "Stage-4 GO/KILL thresholds. See backtester.js + README kill-criteria.",
+    "minNetProfitToFrictionRatio": 2.5,
+    "minWinRate": 0.10,
+    "minNetUsdPerOpportunity": 0.5,
+    "minOpportunitiesPerDay": 5,
+    "maxAcceptableRevertRate": 0.30,
+    "infraCostUsdPerDay": 30.0
+  },
+
+  "chains": {
+    "bsc": {
+      "enabled": true,
+      "chainId": 56,
+      "rpcEnv": "RESEARCH_RPC_BSC",
+      "rpcFallbackEnv": "RESEARCH_RPC_BSC_FALLBACK",
+      "wsEnv": "RESEARCH_WS_BSC",
+      "multicall3": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "baseTokenSymbol": "WBNB",
+      "factories": {
+        "_comment": "Mirror of FACTORIES.bsc in scripts/utils/addresses.js. feeBps MUST be per-fork: PancakeV2=25, Biswap=10, ApeSwap=20. Verified at scan time, never trusted blindly.",
+        "PancakeSwapV2": { "address": "0xcA143Ce32Fe78f1f7019d7d551a6402fC5350c73", "feeBps": 25 },
+        "BiswapV2": { "address": "0x858E3312ed3A876947EA49d572A7C42DE08af7EE", "feeBps": 10 },
+        "ApeSwapV2": { "address": "0x0841BD0B734E4F5853f0dD8d7Ea041c241fb0Da6", "feeBps": 20 }
+      }
+    },
+
+    "base": {
+      "enabled": false,
+      "chainId": 8453,
+      "rpcEnv": "RESEARCH_RPC_BASE",
+      "rpcFallbackEnv": "RESEARCH_RPC_BASE_FALLBACK",
+      "wsEnv": "RESEARCH_WS_BASE",
+      "multicall3": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "baseTokenSymbol": "WETH",
+      "factories": {
+        "UniswapV2": { "address": "0x8909Dc15e40173Ff4699343b6eB8132c65e18eC6", "feeBps": 30 }
+      }
+    },
+
+    "polygon": {
+      "enabled": false,
+      "chainId": 137,
+      "rpcEnv": "RESEARCH_RPC_POLYGON",
+      "rpcFallbackEnv": "RESEARCH_RPC_POLYGON_FALLBACK",
+      "wsEnv": "RESEARCH_WS_POLYGON",
+      "multicall3": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "baseTokenSymbol": "WMATIC",
+      "factories": {
+        "QuickSwapV2": { "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32", "feeBps": 30 },
+        "SushiSwapV2": { "address": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", "feeBps": 30 }
+      }
+    }
+  }
+}

--- a/research/config.js
+++ b/research/config.js
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Config loader for the off-chain research toolkit.
+ *
+ * Responsibilities:
+ *  - Load research/config.json (falling back to config.example.json so the skeleton
+ *    runs out of the box for inspection).
+ *  - Resolve RPC URLs from environment variables (never from the JSON itself).
+ *  - Cross-check factory addresses against the canonical table in
+ *    scripts/utils/addresses.js and WARN on drift (single source of truth lives there).
+ *  - Resolve each chain's base token address from scripts/utils/addresses.js.
+ *
+ * This module is dependency-light on purpose (no ethers, no hardhat) so config can be
+ * validated in isolation and unit-tested offline.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Canonical multi-chain address book shared with the Solidity deploy scripts.
+const addressBook = require('../scripts/utils/addresses.js');
+
+const RESEARCH_DIR = __dirname;
+const CONFIG_PATH = path.join(RESEARCH_DIR, 'config.json');
+const EXAMPLE_PATH = path.join(RESEARCH_DIR, 'config.example.json');
+
+/**
+ * Load the research config, preferring config.json, falling back to the committed example.
+ * @returns {{ config: object, sourcePath: string, isExample: boolean }}
+ */
+function loadConfig() {
+  const usingExample = !fs.existsSync(CONFIG_PATH);
+  const sourcePath = usingExample ? EXAMPLE_PATH : CONFIG_PATH;
+  const raw = fs.readFileSync(sourcePath, 'utf8');
+  const config = JSON.parse(raw);
+  if (usingExample) {
+    console.warn(
+      `[config] research/config.json not found — using ${path.basename(EXAMPLE_PATH)}. ` +
+        'Copy it to config.json and fill in real RPC env vars before running against a live chain.'
+    );
+  }
+  return { config, sourcePath, isExample: usingExample };
+}
+
+/**
+ * Resolve the RPC URL for a chain from its configured env var.
+ * @param {object} chainCfg - One entry from config.chains.
+ * @param {{ allowFallback?: boolean }} [opts]
+ * @returns {string|null} URL or null if the env var is unset.
+ */
+function resolveRpcUrl(chainCfg, opts = {}) {
+  const primary = chainCfg.rpcEnv ? process.env[chainCfg.rpcEnv] : undefined;
+  if (primary) return primary;
+  if (opts.allowFallback && chainCfg.rpcFallbackEnv) {
+    const fb = process.env[chainCfg.rpcFallbackEnv];
+    if (fb) return fb;
+  }
+  return null;
+}
+
+/**
+ * Resolve the WebSocket URL for a chain (for live newHeads subscriptions). May be null.
+ * @param {object} chainCfg
+ * @returns {string|null}
+ */
+function resolveWsUrl(chainCfg) {
+  return chainCfg.wsEnv && process.env[chainCfg.wsEnv] ? process.env[chainCfg.wsEnv] : null;
+}
+
+/**
+ * Resolve the base (wrapped-native) token address for a chain via the canonical address book.
+ * Falls back to the symbol declared in the chain config if the book lacks the network.
+ * @param {string} chainKey - Network key (e.g. "bsc"), must match addresses.js CHAIN_META.
+ * @param {object} chainCfg
+ * @returns {{ symbol: string, address: string|null }}
+ */
+function resolveBaseToken(chainKey, chainCfg) {
+  const symbol = chainCfg.baseTokenSymbol || 'wrappedNative';
+  try {
+    // getBaseToken resolves CHAIN_META.wrappedNative for the network.
+    const address = addressBook.getBaseToken(chainKey);
+    return { symbol, address };
+  } catch (_err) {
+    // Unknown-to-addresses.js chain: caller must supply the address out of band.
+    return { symbol, address: null };
+  }
+}
+
+/**
+ * Compare config factory addresses against scripts/utils/addresses.js and warn on drift.
+ * Does not throw — drift is a signal, not a hard failure, since research chains may be
+ * ahead of the canonical book.
+ * @param {string} chainKey
+ * @param {object} chainCfg
+ * @returns {string[]} list of human-readable drift warnings (also printed)
+ */
+function auditFactoryDrift(chainKey, chainCfg) {
+  const warnings = [];
+  const canonical = (addressBook.FACTORIES || {})[chainKey] || {};
+  const local = chainCfg.factories || {};
+  for (const [dex, entry] of Object.entries(local)) {
+    if (dex.startsWith('_')) continue;
+    const want = canonical[dex];
+    const have = (entry && entry.address) || '';
+    if (want && want.toLowerCase() !== have.toLowerCase()) {
+      const msg = `[config] factory drift on ${chainKey}.${dex}: config=${have} addresses.js=${want}`;
+      warnings.push(msg);
+      console.warn(msg);
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Return the list of enabled chains with resolved RPC/base-token info, ready for the
+ * scanner. RPC may be null when the env var is unset (skeleton-friendly; callers TODO).
+ * @param {object} config
+ * @returns {Array<{ key: string, cfg: object, rpcUrl: string|null, wsUrl: string|null, baseToken: object }>}
+ */
+function enabledChains(config) {
+  const out = [];
+  for (const [key, cfg] of Object.entries(config.chains || {})) {
+    if (key.startsWith('_') || !cfg.enabled) continue;
+    auditFactoryDrift(key, cfg);
+    out.push({
+      key,
+      cfg,
+      rpcUrl: resolveRpcUrl(cfg, { allowFallback: true }),
+      wsUrl: resolveWsUrl(cfg),
+      baseToken: resolveBaseToken(key, cfg)
+    });
+  }
+  return out;
+}
+
+module.exports = {
+  CONFIG_PATH,
+  EXAMPLE_PATH,
+  loadConfig,
+  resolveRpcUrl,
+  resolveWsUrl,
+  resolveBaseToken,
+  auditFactoryDrift,
+  enabledChains
+};

--- a/research/gasModel.js
+++ b/research/gasModel.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * Gas model for net-of-gas PnL.
+ *
+ * WHY THIS FILE EXISTS (the strip decision must be data-driven):
+ * The 6-expert panel's core quantitative claim is that the current BofhContractV2
+ * executor burns ~2-3x the gas of a lean Huff/Yul atomic executor, and that this alone
+ * can erase the long-tail arbitrage edge. The backtester prices EVERY candidate against
+ * BOTH executors so the team can see, in USD, how much edge the fat contract destroys.
+ * If cycles are profitable ONLY for the lean executor, that is a partial KILL signal for
+ * the current contract (strip it) rather than for the strategy.
+ *
+ * ALL CONSTANTS BELOW ARE PLACEHOLDER ESTIMATES — TODO: replace with measured numbers.
+ *  - bofhV2: run `REPORT_GAS=true npx hardhat test` and read executeSwap gas per path
+ *    length, OR trace a real testnet executeSwap. Record base overhead + per-hop cost.
+ *  - leanHuff: take from a public Huff/Yul V2 multi-hop executor benchmark
+ *    (e.g. pawelurbanek.com/mev-yul-huff-gas) or a target you intend to build to.
+ * The numbers here are deliberately conservative round figures so nobody mistakes them
+ * for measurements.
+ */
+
+// Gas profiles: { baseGas, perHopGas }. Total = baseGas + perHopGas * hops, where
+// `hops` = number of swaps in the cycle = path.length - 1.
+const EXECUTOR_PROFILES = {
+  // TODO(measure): BofhContractV2 — fat Solidity executor (current asset). Placeholder.
+  bofhV2: {
+    label: 'BofhContractV2 (current, fat)',
+    baseGas: 120000,
+    perHopGas: 95000,
+    source: 'PLACEHOLDER — measure via REPORT_GAS=true npx hardhat test'
+  },
+  // TODO(measure): lean Huff/Yul target the team would rewrite to. Placeholder.
+  leanHuff: {
+    label: 'Lean Huff/Yul (target)',
+    baseGas: 40000,
+    perHopGas: 38000,
+    source: 'PLACEHOLDER — from public Huff/Yul V2 executor benchmark'
+  }
+};
+
+const GWEI = 1e9;
+
+/**
+ * Estimate gas units for a cycle on a given executor.
+ * @param {number} hops - number of swaps in the cycle (path.length - 1).
+ * @param {string} [executor="bofhV2"] - key in EXECUTOR_PROFILES.
+ * @returns {number} estimated gas units.
+ */
+function estimateGasUnits(hops, executor = 'bofhV2') {
+  const profile = EXECUTOR_PROFILES[executor];
+  if (!profile) {
+    throw new Error(`Unknown executor "${executor}". Known: ${Object.keys(EXECUTOR_PROFILES).join(', ')}`);
+  }
+  if (!Number.isInteger(hops) || hops < 1) {
+    throw new Error(`hops must be a positive integer, got ${hops}`);
+  }
+  return profile.baseGas + profile.perHopGas * hops;
+}
+
+/**
+ * Total per-tx gas price in wei, including the priority fee (tip) the searcher must pay
+ * for inclusion. On private-relay chains (48 Club / bloXroute on BSC) treat priorityFee
+ * as the bribe; raise it in config to stress-test inclusion cost.
+ * @param {{ baseFeeGwei: number, priorityFeeGwei: number }} gasCfg
+ * @returns {number} effective gas price in wei.
+ */
+function effectiveGasPriceWei(gasCfg) {
+  const base = Number(gasCfg.baseFeeGwei || 0);
+  const tip = Number(gasCfg.priorityFeeGwei || 0);
+  return Math.round((base + tip) * GWEI);
+}
+
+/**
+ * Full per-cycle gas cost, in native wei and in USD, for a given executor.
+ * @param {number} hops
+ * @param {{ baseFeeGwei:number, priorityFeeGwei:number, nativeUsdPrice:number }} gasCfg
+ * @param {string} [executor="bofhV2"]
+ * @returns {{ gasUnits:number, gasPriceWei:number, costWei:bigint, costNative:number, costUsd:number, executor:string }}
+ */
+function gasCostForCycle(hops, gasCfg, executor = 'bofhV2') {
+  const gasUnits = estimateGasUnits(hops, executor);
+  const gasPriceWei = effectiveGasPriceWei(gasCfg);
+  const costWei = BigInt(gasUnits) * BigInt(gasPriceWei);
+  const costNative = Number(costWei) / 1e18;
+  const nativeUsd = Number(gasCfg.nativeUsdPrice || 0);
+  const costUsd = costNative * nativeUsd;
+  return { gasUnits, gasPriceWei, costWei, costNative, costUsd, executor };
+}
+
+/**
+ * Convenience: price a cycle against BOTH executors so the strip decision is explicit.
+ * @param {number} hops
+ * @param {object} gasCfg
+ * @returns {{ bofhV2: object, leanHuff: object, overheadUsd: number }}
+ */
+function compareExecutors(hops, gasCfg) {
+  const bofhV2 = gasCostForCycle(hops, gasCfg, 'bofhV2');
+  const leanHuff = gasCostForCycle(hops, gasCfg, 'leanHuff');
+  return { bofhV2, leanHuff, overheadUsd: bofhV2.costUsd - leanHuff.costUsd };
+}
+
+module.exports = {
+  EXECUTOR_PROFILES,
+  estimateGasUnits,
+  effectiveGasPriceWei,
+  gasCostForCycle,
+  compareExecutors
+};

--- a/research/pathfinder.js
+++ b/research/pathfinder.js
@@ -1,0 +1,282 @@
+'use strict';
+
+/**
+ * Stage 2 — Negative-cycle path-finder over a pool snapshot.
+ *
+ * PURE FUNCTIONS over a snapshot object (the output of scanner.js). No RPC, no I/O on the
+ * hot path, so the whole stage is unit-testable offline with a hand-written snapshot.
+ *
+ * METHOD:
+ *  - Build a directed token graph. Each pool contributes TWO directed edges (token0->token1
+ *    and token1->token0). The edge weight is the negative log of the marginal, fee-adjusted
+ *    exchange rate: w = -ln( (1 - fee) * reserveOut / reserveIn ).
+ *  - A round-trip arbitrage cycle exists iff the product of fee-adjusted rates around the
+ *    cycle > 1, i.e. the sum of edge weights < 0 (a NEGATIVE-WEIGHT CYCLE).
+ *  - We run Bellman-Ford seeded at the baseToken and use the relaxation-on-the-Nth-pass
+ *    trick to detect a negative cycle, then walk predecessors to recover it.
+ *
+ * IMPORTANT CAVEAT (baked in from the research):
+ *  Bellman-Ford finds cycles using the MARGINAL (infinitesimal) rate and reports a
+ *  PERCENTAGE edge. It CANNOT net out absolute gas, and the marginal rate overstates
+ *  realised profit because price impact grows with trade size. Therefore this module is a
+ *  CANDIDATE GENERATOR only. Final sizing + net-of-gas USD ranking happens in backtester.js.
+ *
+ * Constraints mirrored from the contract: cycles start and end at baseToken; hop count is
+ * clamped to [minHops, maxHops] with maxHops <= MAX_PATH_LENGTH (5).
+ */
+
+/**
+ * Per-hop constant-product (x*y=k) output, fee applied to input. Mirrors UniswapV2.
+ * All amounts are BigInt (wei-scale). feeBps is basis points of the INPUT taken as fee.
+ * @param {bigint} amountIn
+ * @param {bigint} reserveIn
+ * @param {bigint} reserveOut
+ * @param {number} feeBps - e.g. 25 for 0.25%.
+ * @returns {bigint} amountOut
+ */
+function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+  if (amountIn <= 0n) return 0n;
+  if (reserveIn <= 0n || reserveOut <= 0n) return 0n;
+  const feeDen = 10000n;
+  const feeNum = feeDen - BigInt(feeBps); // e.g. 9975 for 0.25%
+  const amountInWithFee = amountIn * feeNum;
+  const numerator = amountInWithFee * reserveOut;
+  const denominator = reserveIn * feeDen + amountInWithFee;
+  return numerator / denominator;
+}
+
+/**
+ * Marginal (size-zero) fee-adjusted rate out-per-in for an edge, as a JS number.
+ * Used only for negative-cycle DETECTION; never for profit sizing.
+ * @param {bigint} reserveIn
+ * @param {bigint} reserveOut
+ * @param {number} feeBps
+ * @returns {number} effective rate; 0 if a reserve is empty.
+ */
+function marginalRate(reserveIn, reserveOut, feeBps) {
+  if (reserveIn <= 0n || reserveOut <= 0n) return 0;
+  const feeFactor = (10000 - feeBps) / 10000;
+  // Use Number() on the ratio; for detection the magnitude of reserves cancels.
+  return feeFactor * (Number(reserveOut) / Number(reserveIn));
+}
+
+/**
+ * Build a directed graph from a snapshot.
+ * @param {object} snapshot - scanner.js snapshot (must have .pools).
+ * @param {{ minEdgeReserveBaseToken?: string|number }} [opts] - reserved for future filtering.
+ * @returns {{ nodes: string[], edges: Array<object>, adjacency: Map<string, object[]> }}
+ *   each edge: { from, to, reserveIn, reserveOut, feeBps, pair, dex, weight }
+ */
+function buildGraph(snapshot, opts = {}) {
+  void opts; // reserved (e.g. min-liquidity pruning); kept for signature stability.
+  const nodeSet = new Set();
+  const edges = [];
+  const adjacency = new Map();
+
+  const addEdge = (from, to, reserveIn, reserveOut, feeBps, pair, dex) => {
+    const rate = marginalRate(reserveIn, reserveOut, feeBps);
+    if (rate <= 0) return; // dead/empty pool direction
+    const weight = -Math.log(rate);
+    const edge = { from, to, reserveIn, reserveOut, feeBps, pair, dex, weight };
+    edges.push(edge);
+    nodeSet.add(from);
+    nodeSet.add(to);
+    if (!adjacency.has(from)) adjacency.set(from, []);
+    adjacency.get(from).push(edge);
+  };
+
+  for (const p of snapshot.pools || []) {
+    const r0 = BigInt(p.reserve0);
+    const r1 = BigInt(p.reserve1);
+    addEdge(p.token0, p.token1, r0, r1, p.feeBps, p.pair, p.dex);
+    addEdge(p.token1, p.token0, r1, r0, p.feeBps, p.pair, p.dex);
+  }
+
+  return { nodes: [...nodeSet], edges, adjacency };
+}
+
+/**
+ * Detect ONE negative-weight cycle reachable from `source` via Bellman-Ford.
+ * Returns the cycle as an ordered list of token addresses starting and ending at the same
+ * node, or null if none found within the relaxation bound.
+ * @param {{ nodes:string[], edges:object[] }} graph
+ * @param {string} source
+ * @returns {string[]|null}
+ */
+function findNegativeCycleFrom(graph, source) {
+  const dist = new Map();
+  const pred = new Map();
+  for (const n of graph.nodes) dist.set(n, Infinity);
+  if (!dist.has(source)) return null;
+  dist.set(source, 0);
+
+  const V = graph.nodes.length;
+
+  // Phase 1: |V|-1 relaxation passes. `anyRelaxed` drives the early-exit optimisation;
+  // it is INDEPENDENT of negative-cycle detection (which happens in phase 2). A 3-node
+  // graph can host a 3-edge cycle that needs all |V|-1 passes to propagate, so we must
+  // not conflate "no node relaxed" with "no negative cycle".
+  for (let i = 0; i < V - 1; i++) {
+    let anyRelaxed = false;
+    for (const e of graph.edges) {
+      const du = dist.get(e.from);
+      if (du === Infinity) continue;
+      const nd = du + e.weight;
+      if (nd < dist.get(e.to) - 1e-12) {
+        dist.set(e.to, nd);
+        pred.set(e.to, e.from);
+        anyRelaxed = true;
+      }
+    }
+    if (!anyRelaxed) break; // distances converged => no negative cycle reachable
+  }
+
+  // Phase 2: one more pass. Any edge that still relaxes sits on (or downstream of) a
+  // negative-weight cycle.
+  let relaxedNode = null;
+  for (const e of graph.edges) {
+    const du = dist.get(e.from);
+    if (du === Infinity) continue;
+    if (du + e.weight < dist.get(e.to) - 1e-12) {
+      pred.set(e.to, e.from);
+      relaxedNode = e.to;
+      break;
+    }
+  }
+
+  if (relaxedNode === null) return null;
+
+  // Walk predecessors V times to land squarely inside the cycle, then extract it.
+  let cur = relaxedNode;
+  for (let i = 0; i < V; i++) cur = pred.get(cur);
+
+  const cycle = [cur];
+  let node = pred.get(cur);
+  while (node !== undefined && node !== cur) {
+    cycle.push(node);
+    node = pred.get(node);
+  }
+  cycle.push(cur);
+  cycle.reverse();
+  return cycle;
+}
+
+/**
+ * Rotate a raw cycle so it starts (and ends) at baseToken, if baseToken is part of it.
+ * @param {string[]} cycle - closed walk (first === last).
+ * @param {string} baseToken
+ * @returns {string[]|null} rotated closed walk anchored at baseToken, or null.
+ */
+function anchorCycleAtBase(cycle, baseToken) {
+  if (!cycle || cycle.length < 3) return null;
+  const open = cycle.slice(0, -1); // drop duplicate tail
+  const idx = open.findIndex((t) => t.toLowerCase() === baseToken.toLowerCase());
+  if (idx === -1) return null;
+  const rotated = open.slice(idx).concat(open.slice(0, idx));
+  rotated.push(rotated[0]); // re-close
+  return rotated;
+}
+
+/**
+ * For an anchored token cycle, resolve the concrete pool/edge per hop, preferring the edge
+ * with the best marginal rate when several forks connect the same pair.
+ * @param {{ adjacency: Map<string, object[]> }} graph
+ * @param {string[]} tokenCycle - anchored closed walk (first === last).
+ * @returns {Array<object>|null} per-hop edges, or null if any hop has no edge.
+ */
+function resolveCycleEdges(graph, tokenCycle) {
+  const hops = [];
+  for (let i = 0; i < tokenCycle.length - 1; i++) {
+    const from = tokenCycle[i];
+    const to = tokenCycle[i + 1];
+    const candidates = (graph.adjacency.get(from) || []).filter((e) => e.to === to);
+    if (candidates.length === 0) return null;
+    // Pick the most favourable fork for this hop (lowest weight = best rate).
+    candidates.sort((a, b) => a.weight - b.weight);
+    hops.push(candidates[0]);
+  }
+  return hops;
+}
+
+/**
+ * Find candidate profitable round-trip cycles anchored at baseToken.
+ *
+ * Strategy: repeatedly find a negative cycle, anchor it at baseToken, record it, then
+ * "break" its best edge (mark it used) and retry, up to `topN` candidates. This is a
+ * pragmatic enumeration — NOT exhaustive — sufficient for a candidate generator. A
+ * production version would use Johnson's algorithm or line-graph MMBF for completeness.
+ *
+ * @param {object} snapshot
+ * @param {object} [cfg] - pathfinder config block: { maxHops, minHops, topN }.
+ * @returns {Array<{ tokens:string[], hops:object[], marginalEdgePct:number }>}
+ */
+function findCandidateCycles(snapshot, cfg = {}) {
+  const baseToken = snapshot.baseToken;
+  if (!baseToken) {
+    console.warn('[pathfinder] snapshot.baseToken is null — set it in the snapshot/config. No cycles.');
+    return [];
+  }
+  const maxHops = cfg.maxHops || 5;
+  const minHops = cfg.minHops || 2;
+  const topN = cfg.topN || 50;
+
+  const graph = buildGraph(snapshot);
+  const results = [];
+  const usedEdgeKeys = new Set();
+
+  const edgeKey = (e) => `${e.pair}:${e.from}->${e.to}`;
+
+  for (let attempt = 0; attempt < topN * 4 && results.length < topN; attempt++) {
+    // Rebuild a working graph excluding already-consumed edges so we surface new cycles.
+    const workEdges = graph.edges.filter((e) => !usedEdgeKeys.has(edgeKey(e)));
+    if (workEdges.length === 0) break;
+    const workAdj = new Map();
+    for (const e of workEdges) {
+      if (!workAdj.has(e.from)) workAdj.set(e.from, []);
+      workAdj.get(e.from).push(e);
+    }
+    const workGraph = { nodes: graph.nodes, edges: workEdges, adjacency: workAdj };
+
+    const rawCycle = findNegativeCycleFrom(workGraph, baseToken);
+    if (!rawCycle) break;
+
+    const anchored = anchorCycleAtBase(rawCycle, baseToken);
+    if (!anchored) {
+      // Cycle didn't touch base; consume its edges anyway to make progress.
+      const edges = resolveCycleEdges(workGraph, rawCycle);
+      if (edges) edges.forEach((e) => usedEdgeKeys.add(edgeKey(e)));
+      continue;
+    }
+
+    const hops = resolveCycleEdges(workGraph, anchored);
+    if (!hops) continue;
+
+    const hopCount = hops.length;
+    // Consume the best (lowest-weight) edge so the next attempt explores elsewhere.
+    const breakEdge = hops.slice().sort((a, b) => a.weight - b.weight)[0];
+    usedEdgeKeys.add(edgeKey(breakEdge));
+
+    if (hopCount < minHops || hopCount > maxHops) continue;
+
+    // Marginal (size-zero) edge as a percentage: product of rates - 1.
+    const logSum = hops.reduce((s, e) => s + e.weight, 0);
+    const marginalEdgePct = (Math.exp(-logSum) - 1) * 100;
+    if (marginalEdgePct <= 0) continue;
+
+    results.push({ tokens: anchored, hops, marginalEdgePct });
+  }
+
+  // Best marginal edge first (final ranking by absolute USD is the backtester's job).
+  results.sort((a, b) => b.marginalEdgePct - a.marginalEdgePct);
+  return results;
+}
+
+module.exports = {
+  getAmountOut,
+  marginalRate,
+  buildGraph,
+  findNegativeCycleFrom,
+  anchorCycleAtBase,
+  resolveCycleEdges,
+  findCandidateCycles
+};

--- a/research/run.js
+++ b/research/run.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Thin orchestrator that runs the offline Stage 2->4 pipeline over an EXISTING snapshot
+ * file, so the path-finder + backtester can be exercised with zero RPC. Use this to
+ * sanity-check the toolkit and to replay a recorded snapshot.
+ *
+ * Usage:
+ *   node research/run.js <snapshot.json>
+ *   node research/run.js --demo            # build a tiny in-memory snapshot and run it
+ *
+ * For live scanning use:  node research/scanner.js   (needs RPC env vars; see README)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { loadConfig } = require('./config.js');
+const { findCandidateCycles } = require('./pathfinder.js');
+const { runBacktest, printReport } = require('./backtester.js');
+
+/**
+ * A tiny synthetic snapshot with a deliberate triangular arbitrage, so the pipeline
+ * produces a non-empty report offline without any chain access. NOT representative —
+ * for wiring/smoke-testing only.
+ * @returns {object} snapshot
+ */
+function demoSnapshot() {
+  const BASE = '0x0000000000000000000000000000000000000B45';
+  const A = '0x000000000000000000000000000000000000000A';
+  const B = '0x000000000000000000000000000000000000000B';
+  const e = (n) => (BigInt(n) * 10n ** 18n).toString();
+  return {
+    version: 1,
+    chainKey: 'demo',
+    chainId: 0,
+    blockNumber: 0,
+    baseToken: BASE,
+    baseTokenSymbol: 'WBASE',
+    takenAtIso: new Date().toISOString(),
+    tokens: {
+      [BASE]: { symbol: 'WBASE', decimals: 18, probed: true },
+      [A]: { symbol: 'AAA', decimals: 18, probed: true },
+      [B]: { symbol: 'BBB', decimals: 18, probed: true }
+    },
+    // Reserves are skewed so BASE->A->B->BASE round-trips for a small marginal edge.
+    pools: [
+      { pair: '0x00000000000000000000000000000000000000P1', dex: 'DexX', token0: BASE, token1: A, reserve0: e(1000), reserve1: e(2050), feeBps: 25 },
+      { pair: '0x00000000000000000000000000000000000000P2', dex: 'DexY', token0: A, token1: B, reserve0: e(2000), reserve1: e(1000), feeBps: 25 },
+      { pair: '0x00000000000000000000000000000000000000P3', dex: 'DexZ', token0: B, token1: BASE, reserve0: e(1000), reserve1: e(1010), feeBps: 25 }
+    ]
+  };
+}
+
+function loadSnapshot(arg) {
+  if (arg === '--demo' || !arg) return demoSnapshot();
+  const abs = path.isAbsolute(arg) ? arg : path.join(process.cwd(), arg);
+  return JSON.parse(fs.readFileSync(abs, 'utf8'));
+}
+
+function main() {
+  const arg = process.argv[2];
+  const { config } = loadConfig();
+  const snapshot = loadSnapshot(arg);
+
+  console.log(
+    `[run] snapshot chain=${snapshot.chainKey} block=${snapshot.blockNumber} ` +
+      `pools=${(snapshot.pools || []).length} base=${snapshot.baseToken}`
+  );
+
+  const candidates = findCandidateCycles(snapshot, config.pathfinder || {});
+  console.log(`[run] candidate cycles: ${candidates.length}`);
+
+  // obs left mostly empty on purpose: win-rate falls back to config, revert-rate is
+  // unmeasured (forces a provisional verdict + the revm TODO warning).
+  const result = runBacktest(snapshot, candidates, config, { windowDays: 1 });
+  printReport(result);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (err) {
+    console.error('[run] fatal:', err.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { demoSnapshot };

--- a/research/scanner.js
+++ b/research/scanner.js
@@ -1,0 +1,283 @@
+'use strict';
+
+/**
+ * Stage 1 — Multi-fork V2 pool scanner (ethers v6).
+ *
+ * GOAL: produce a "pool snapshot" — a static, offline-replayable JSON file describing
+ * every V2-fork pool of interest on a target chain at a given block, with reserves, the
+ * token ordering, and the PER-FORK swap fee. The pathfinder and backtester consume this
+ * snapshot as a pure input, so the entire research pipeline is reproducible offline.
+ *
+ * This REPLACES scripts/find-arbitrage.js, which is a Hardhat mock-pool demo (it deploys
+ * MockPair/MockFactory and fabricates reserves). Here the getReserves/token0/token1 calls
+ * are REAL ethers v6 contract calls against a real RPC.
+ *
+ * STATUS: runnable skeleton.
+ *  - REAL: getReserves(), token0(), token1() against live pairs via ethers v6.
+ *  - TODO: full pair ENUMERATION (replay PairCreated logs OR allPairsLength+allPairs(i)),
+ *    Multicall3 batching of getReserves, persistence to a real registry (Postgres/Parquet),
+ *    and per-fork fee VERIFICATION on-chain instead of trusting config.
+ *
+ * Snapshot schema (v1):
+ * {
+ *   "version": 1,
+ *   "chainKey": "bsc",
+ *   "chainId": 56,
+ *   "blockNumber": 1234567,
+ *   "baseToken": "0x...",
+ *   "takenAtIso": "2026-06-05T00:00:00.000Z",
+ *   "tokens": { "0xabc...": { "symbol": "?", "decimals": 18 }, ... },
+ *   "pools": [
+ *     { "pair":"0x..","factory":"0x..","dex":"PancakeSwapV2","token0":"0x..","token1":"0x..",
+ *       "reserve0":"123","reserve1":"456","feeBps":25 }, ...
+ *   ]
+ * }
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { ethers } = require('ethers');
+
+const { loadConfig, enabledChains } = require('./config.js');
+
+// Minimal ABIs — only the read methods we need.
+const PAIR_ABI = [
+  'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+  'function token0() view returns (address)',
+  'function token1() view returns (address)'
+];
+
+const FACTORY_ABI = [
+  'function allPairsLength() view returns (uint256)',
+  'function allPairs(uint256) view returns (address)',
+  'event PairCreated(address indexed token0, address indexed token1, address pair, uint256)'
+];
+
+const ERC20_ABI = [
+  'function symbol() view returns (string)',
+  'function decimals() view returns (uint8)'
+];
+
+const SNAPSHOT_VERSION = 1;
+
+/**
+ * Build an ethers v6 JsonRpcProvider for a chain, or null if no RPC env var is set.
+ * @param {object} chain - element from enabledChains().
+ * @returns {ethers.JsonRpcProvider|null}
+ */
+function makeProvider(chain) {
+  if (!chain.rpcUrl) {
+    console.warn(
+      `[scanner] no RPC for chain "${chain.key}" — set env ${chain.cfg.rpcEnv} (or fallback). Skipping.`
+    );
+    return null;
+  }
+  // staticNetwork avoids an extra eth_chainId round-trip per call.
+  return new ethers.JsonRpcProvider(chain.rpcUrl, chain.cfg.chainId, {
+    staticNetwork: true
+  });
+}
+
+/**
+ * REAL read of a single pair's on-chain state. This is the load-bearing live call.
+ * @param {ethers.Provider} provider
+ * @param {string} pairAddress
+ * @param {number|string} feeBps - per-fork fee, basis points (e.g. 25 = 0.25%).
+ * @param {object} [meta] - { factory, dex } provenance to embed in the pool record.
+ * @returns {Promise<object>} pool record for the snapshot.
+ */
+async function readPair(provider, pairAddress, feeBps, meta = {}) {
+  const pair = new ethers.Contract(pairAddress, PAIR_ABI, provider);
+  // ethers v6 returns bigints; getReserves returns a Result tuple.
+  const [reserves, token0, token1] = await Promise.all([
+    pair.getReserves(),
+    pair.token0(),
+    pair.token1()
+  ]);
+  return {
+    pair: ethers.getAddress(pairAddress),
+    factory: meta.factory ? ethers.getAddress(meta.factory) : null,
+    dex: meta.dex || null,
+    token0: ethers.getAddress(token0),
+    token1: ethers.getAddress(token1),
+    reserve0: reserves[0].toString(),
+    reserve1: reserves[1].toString(),
+    feeBps: Number(feeBps)
+  };
+}
+
+/**
+ * Enumerate the pairs of a single factory.
+ *
+ * TODO(real-enumeration): the production path is one of:
+ *   (a) replay PairCreated logs in block ranges via provider.getLogs({ address: factory,
+ *       topics: [PairCreated] }) and decode with the factory interface; OR
+ *   (b) read allPairsLength() then allPairs(i) for i in [0, len), batched via Multicall3.
+ * Both are O(#pairs) and must be paginated. For thin/long-tail chains the PairCreated
+ * replay is preferred because it also gives you creation block (freshness signal).
+ *
+ * This skeleton only returns an EXPLICIT seed list if provided in config
+ * (chainCfg.factories[dex].seedPairs), so the rest of the pipeline is runnable without
+ * a full enumeration. Returns [] otherwise (with a TODO warning).
+ *
+ * @param {ethers.Provider} provider
+ * @param {string} dex
+ * @param {{ address: string, feeBps: number, seedPairs?: string[] }} factoryCfg
+ * @param {{ maxPairsPerFactory: number }} scanCfg
+ * @returns {Promise<Array<{ pair:string, factory:string, dex:string, feeBps:number }>>}
+ */
+async function enumeratePairs(provider, dex, factoryCfg, scanCfg) {
+  const factoryAddr = factoryCfg.address;
+
+  // Skeleton fast-path: explicit seed pairs let the whole toolkit run end-to-end now.
+  if (Array.isArray(factoryCfg.seedPairs) && factoryCfg.seedPairs.length > 0) {
+    return factoryCfg.seedPairs.map((p) => ({
+      pair: p,
+      factory: factoryAddr,
+      dex,
+      feeBps: Number(factoryCfg.feeBps)
+    }));
+  }
+
+  // Sanity-probe the factory so the skeleton at least proves connectivity + ABI.
+  try {
+    const factory = new ethers.Contract(factoryAddr, FACTORY_ABI, provider);
+    const len = await factory.allPairsLength();
+    console.warn(
+      `[scanner] ${dex} (${factoryAddr}) has ${len.toString()} pairs. ` +
+        'TODO: implement real enumeration (PairCreated replay or allPairs(i) + Multicall3). ' +
+        'Returning [] for now — add "seedPairs" in config to test downstream stages.'
+    );
+  } catch (err) {
+    console.warn(`[scanner] could not probe factory ${dex} (${factoryAddr}): ${err.message}`);
+  }
+  return [];
+}
+
+/**
+ * Best-effort token metadata (symbol/decimals). Failures are non-fatal — many long-tail
+ * tokens have non-standard or missing metadata; we keep decimals=18 as a placeholder and
+ * flag it. TODO: batch via Multicall3 and cache to the registry.
+ * @param {ethers.Provider} provider
+ * @param {Set<string>} tokenAddrs
+ * @returns {Promise<Record<string,{symbol:string,decimals:number,probed:boolean}>>}
+ */
+async function readTokenMeta(provider, tokenAddrs) {
+  const out = {};
+  for (const addr of tokenAddrs) {
+    try {
+      const erc = new ethers.Contract(addr, ERC20_ABI, provider);
+      const [symbol, decimals] = await Promise.all([erc.symbol(), erc.decimals()]);
+      out[addr] = { symbol, decimals: Number(decimals), probed: true };
+    } catch (_err) {
+      out[addr] = { symbol: '?', decimals: 18, probed: false };
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan a single chain into a snapshot object (does not write to disk).
+ * @param {object} chain - element from enabledChains().
+ * @param {object} config - full research config.
+ * @returns {Promise<object|null>} snapshot, or null if the chain was skipped.
+ */
+async function scanChain(chain, config) {
+  const provider = makeProvider(chain);
+  if (!provider) return null;
+
+  const scanCfg = config.scan || {};
+  const blockNumber = await provider.getBlockNumber();
+
+  const pools = [];
+  const factories = chain.cfg.factories || {};
+  for (const [dex, factoryCfg] of Object.entries(factories)) {
+    if (dex.startsWith('_')) continue;
+    const candidates = await enumeratePairs(provider, dex, factoryCfg, scanCfg);
+    for (const c of candidates) {
+      try {
+        const rec = await readPair(provider, c.pair, c.feeBps, { factory: c.factory, dex: c.dex });
+        pools.push(rec);
+      } catch (err) {
+        console.warn(`[scanner] failed reading pair ${c.pair} on ${dex}: ${err.message}`);
+      }
+    }
+  }
+
+  const tokenAddrs = new Set();
+  for (const p of pools) {
+    tokenAddrs.add(p.token0);
+    tokenAddrs.add(p.token1);
+  }
+  const tokens = await readTokenMeta(provider, tokenAddrs);
+
+  return {
+    version: SNAPSHOT_VERSION,
+    chainKey: chain.key,
+    chainId: chain.cfg.chainId,
+    blockNumber,
+    baseToken: chain.baseToken.address, // may be null if addresses.js lacks the chain (TODO)
+    baseTokenSymbol: chain.baseToken.symbol,
+    takenAtIso: new Date().toISOString(),
+    tokens,
+    pools
+  };
+}
+
+/**
+ * Write a snapshot to disk (creates parent dirs). Returns the path written.
+ * @param {object} snapshot
+ * @param {string} outPath
+ * @returns {string}
+ */
+function writeSnapshot(snapshot, outPath) {
+  const abs = path.isAbsolute(outPath) ? outPath : path.join(process.cwd(), outPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(snapshot, null, 2));
+  return abs;
+}
+
+/**
+ * CLI entrypoint: scan all enabled chains and write one snapshot per chain.
+ */
+async function main() {
+  const { config, sourcePath } = loadConfig();
+  console.log(`[scanner] config: ${sourcePath}`);
+  const chains = enabledChains(config);
+  if (chains.length === 0) {
+    console.warn('[scanner] no enabled chains. Enable one in research/config.json.');
+    return;
+  }
+
+  for (const chain of chains) {
+    console.log(`[scanner] scanning ${chain.key} (chainId ${chain.cfg.chainId})...`);
+    const snapshot = await scanChain(chain, config);
+    if (!snapshot) continue;
+
+    const base = (config.scan && config.scan.snapshotOutPath) || 'research/data/snapshot.json';
+    const outPath = base.replace(/snapshot/, `snapshot.${chain.key}`);
+    const written = writeSnapshot(snapshot, outPath);
+    console.log(
+      `[scanner] ${chain.key}: ${snapshot.pools.length} pools @ block ${snapshot.blockNumber} -> ${written}`
+    );
+  }
+}
+
+module.exports = {
+  SNAPSHOT_VERSION,
+  PAIR_ABI,
+  FACTORY_ABI,
+  makeProvider,
+  readPair,
+  enumeratePairs,
+  readTokenMeta,
+  scanChain,
+  writeSnapshot
+};
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[scanner] fatal:', err);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
The expert panel's core finding: **this contract is the replaceable commodity executor; the real edge is off-chain and does not exist in the repo** (`find-arbitrage.js` is a confirmed mock-pool demo). This PR bootstraps the **kill-criteria-driven research system** to PROVE or KILL a profitable edge on real chain data **before any audit spend** — the panel's critical sequencing step.

## `research/` — read-only off-chain toolkit (ethers v6 skeletons, honest TODOs where real RPC/data is needed)
| File | Job |
|---|---|
| `scanner.js` | Enumerate V2 factories + pairs across target chains; snapshot reserves + fees |
| `pathfinder.js` | Negative-log-weight cycle detection (Bellman-Ford) over the token graph for round-trip `baseToken` arb |
| `backtester.js` | Net-of-gas PnL; **fat (this contract) vs lean executor** gas model; explicit GO/KILL verdict |
| `gasModel.js` | Documented per-hop gas constants so the strip/rewrite decision is data-driven |
| `run.js` | Pipeline + offline `--demo` smoke test |
| `README.md` / `config.example.json` | Methodology + setup |

Offline smoke test works end-to-end:
```
$ node research/run.js --demo
...
VERDICT: KILL
  - KILL(2): expected daily net $3.64 < infra cost $30.00 (winRate=0.1)
  - WARN: revert rate NOT measured (revm/Anvil re-simulation TODO) — a GO here is provisional
  - KILL(0): only 1.00 profitable ops/day < 5 required
```
(synthetic data — the point is the methodology: it refuses to greenlight without real net-of-gas evidence.)

## `docs/STRATEGY_AND_REALITY.md` — the founding-team report
What we made real (companion to #42), the honest verdict, the **web-grounded strategy landscape** for a small team — **#1 long-tail / fresh-launch V2-fork backrunning on under-contested chains**, **#2 OEV/auction backrunning** as a hedge — the kill-criteria methodology, decision gates (**prove edge → strip contract → audit last**), and a concrete next-2-weeks plan.

## Verification
- `node --check` on all `research/*.js` ✅ · `node research/run.js --demo` runs end-to-end ✅

> Pairs with #42 (the "restore reality" code cleanup). Together they implement the panel's recommendation: stop polishing the commodity, and go prove the off-chain edge before spending on an audit.