### PR TITLE
docs+research: finish restore-reality (audit/security docs) + research-toolkit nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@
   - Geometric mean liquidity calculation
   - Newton's method for precision (sqrt, cbrt)
 
-- **Dynamic Programming**
-  - Bellman equation implementation
-  - Optimal routing across multiple hops
+- **Caller-Supplied Routing**
+  - Paths are chosen off-chain and passed in by the caller
+  - The contract executes the given path hop-by-hop (no on-chain routing)
+  - Per-hop price-impact validation via `PoolLib.validateSwap`
 
 </td>
 <td width="50%">
@@ -586,22 +587,19 @@ For each hop (reserveIn, reserveOut, feeBps):
 
 ### Price Impact Model
 
-**CPMM Analysis:**
+**Per-hop constant-product (CPMM):**
 
-Third-order Taylor expansion:
+Output pricing (`SwapMathLib.getAmountOut`) — per-hop fee on a 10000 basis:
 
 ```
-ΔP   =  -λ(ΔR/R)
-───
- P
-     + (λ²/2)(ΔR/R)²
-     - (λ³/6)(ΔR/R)³
+amountInWithFee = amountIn * (10000 - feeBps)
+amountOut = (amountInWithFee * reserveOut)
+            / (reserveIn * 10000 + amountInWithFee)
 ```
 
-**Where:**
-- `λ` = market depth parameter
-- `ΔR/R` = relative reserve change
-- `ΔP/P` = relative price change
+Price impact is computed **separately** and exactly from the x·y=k reserves
+(`PoolLib.calculatePriceImpact`, no λ / Taylor model) and checked against the
+configured per-hop cap in `PoolLib.validateSwap`.
 
 **Implementation:**
 - `MathLib.sol` - Fixed-point helpers (sqrt, cbrt, log2, exp2)
@@ -611,7 +609,8 @@ Third-order Taylor expansion:
 **Mathematical Rigor:**
 - Newton's method for √ and ∛
 - Geometric mean for liquidity
-- Bellman equations for routing
+- Routing is caller-supplied (off-chain); the contract does **no** on-chain
+  Bellman / dynamic-programming routing
 
 </td>
 </tr>

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,5 +1,12 @@
 # BofhContract API Reference
 
+> **Correction notice.** The "golden ratio-based path distribution / optimization" described
+> below was **never wired into production and has been removed**. `BofhContractV2` is a
+> **sequential constant-product (x·y=k) multi-hop / multi-DEX atomic executor**: it runs a
+> caller-supplied path hop-by-hop with no on-chain amount-splitting or golden-ratio
+> optimization. Treat any "golden ratio" / `calculateOptimalAmount` reference here as
+> historical.
+
 ## Table of Contents
 - [Overview](#overview)
 - [BofhContractV2](#bofhcontractv2)

--- a/docs/AUDIT_PREPARATION.md
+++ b/docs/AUDIT_PREPARATION.md
@@ -9,7 +9,13 @@
 
 ## Executive Summary
 
-BofhContract V2 is an advanced multi-path token swap optimizer for Binance Smart Chain implementing golden ratio-based optimization algorithms. The system has undergone extensive internal testing, achieving 94% production code coverage and implementing comprehensive security measures.
+> **Correction notice.** References to "golden ratio-based optimization" / `calculateOptimalAmount`
+> / "third-order Taylor" price-impact in this document are **historical**: that optimization
+> was never wired into production and has been **removed**. The actual audit target is a
+> **sequential constant-product (x·y=k) multi-hop / multi-DEX atomic executor** that runs a
+> caller-supplied path hop-by-hop, with per-hop CPMM price-impact validation in `PoolLib`.
+
+BofhContract V2 is a multi-path token swap / arbitrage router for EVM chains (BSC, Polygon, Base, …): a sequential constant-product (x·y=k) multi-hop / multi-DEX atomic executor that runs caller-supplied paths hop-by-hop with per-hop CPMM price-impact validation. It has undergone extensive internal testing and implements comprehensive security measures. It performs **no on-chain path optimization** — the earlier golden-ratio claims described removed dead code.
 
 **Audit Scope:** ~1,510 lines of production Solidity code
 **Test Coverage:** 94% (179 passing tests)
@@ -63,7 +69,7 @@ BofhContractV2 (Main Implementation)
 
 ### Key Features
 
-1. **Golden Ratio Optimization** - φ-based path splitting for 4/5-way swaps
+1. **Multi-DEX Routing** - per-hop DEX registry (dexId → factory/fee), fee-correct sequential CPMM execution of caller-supplied paths (no on-chain optimization)
 2. **MEV Protection** - Flash loan detection + rate limiting
 3. **Batch Operations** - Atomic multi-swap execution (up to 10 swaps)
 4. **Emergency Controls** - Circuit breakers, pause functionality, token recovery
@@ -172,7 +178,7 @@ BofhContractV2 (Main Implementation)
 
 4. **Price Manipulation**
    - Mitigation: Pool liquidity checks, price impact limits
-   - Coverage: Third-order Taylor expansion for CPMM analysis
+   - Coverage: Per-hop constant-product (x·y=k) price-impact cap (PoolLib.validateSwap)
 
 5. **Access Control Bypass**
    - Mitigation: Owner/operator roles, comprehensive checks
@@ -194,25 +200,20 @@ BofhContractV2 (Main Implementation)
 
 ### Critical Mathematical Components
 
-1. **Golden Ratio Distribution** (φ ≈ 0.618034)
-   - Used for optimal multi-path splitting
-   - Implementation: MathLib.sol lines 45-80
-   - **Audit Focus:** Verify optimality proofs
+1. **Constant-Product Pricing with Fee** (x·y=k)
+   - Single shared formula: amountInWithFee = amountIn·(10000−feeBps); out = amountInWithFee·reserveOut / (reserveIn·10000 + amountInWithFee)
+   - Implementation: SwapMathLib.getAmountOut (shared by the swap hot path and the fee-aware views)
+   - **Audit Focus:** Rounding/truncation, overflow, fee-bps bounds (≤ MAX_FEE_BPS = 1000)
 
 2. **Newton's Method** (Square Root, Cube Root)
    - Iterative approximation for roots
    - Implementation: MathLib.sol lines 20-44, 82-115
    - **Audit Focus:** Convergence guarantees, precision
 
-3. **CPMM Price Impact** (Third-order Taylor Expansion)
-   - ΔP/P = -λ(ΔR/R) + (λ²/2)(ΔR/R)² - (λ³/6)(ΔR/R)³
-   - Implementation: PoolLib.sol lines 120-150
-   - **Audit Focus:** Approximation accuracy
-
-4. **Geometric Mean** (Pool Reserve Analysis)
-   - Uses log approximation for large values
-   - Implementation: MathLib.sol lines 117-145
-   - **Audit Focus:** Overflow protection
+3. **CPMM Price Impact** (exact x·y=k, no Taylor approximation)
+   - Marginal-price deviation computed directly from the constant-product reserves; capped per-hop at maxPriceImpact
+   - Implementation: PoolLib.calculatePriceImpact / PoolLib.validateSwap
+   - **Audit Focus:** Per-hop cap enforcement; impact-vs-trader-slippage semantics
 
 **Documentation:** See [MATHEMATICAL_FOUNDATIONS.md](MATHEMATICAL_FOUNDATIONS.md)
 
@@ -300,8 +301,8 @@ BofhContractV2 (Main Implementation)
 
 3. **MathLib.sol**
    - `sqrt` / `cbrt` - Newton's method implementation
-   - `geometricMean` - Log approximation
-   - `calculateOptimalAmount` - Golden ratio distribution
+   - `exp2` / `log2` - fixed-point primitives
+   (golden-ratio `calculateOptimalAmount` and `geometricMean` were never wired into execution and have been removed)
 
 4. **PoolLib.sol**
    - `analyzePool` - Pool state analysis
@@ -490,9 +491,9 @@ contracts/
 uint256 constant PRECISION = 1e6;              // Base precision
 uint256 constant MAX_SLIPPAGE = 1e4;           // 1% (10000 = 1%)
 uint256 constant MIN_OPTIMALITY = 5e5;         // 50% (500000 = 50%)
-uint256 constant MAX_PATH_LENGTH = 5;          // Maximum swap hops
+uint256 constant MAX_PATH_LENGTH = 6;          // Max tokens per path (= 5 hops)
 uint256 constant MAX_BATCH_SIZE = 10;          // Maximum batch swaps
-uint256 constant GOLDEN_RATIO = 618034;        // φ * 1e6
+uint256 constant MAX_FEE_BPS = 1000;           // Max per-hop fee (10%)
 ```
 
 ### C. Event Definitions

--- a/docs/MATHEMATICAL_FOUNDATIONS.md
+++ b/docs/MATHEMATICAL_FOUNDATIONS.md
@@ -1,5 +1,22 @@
 # Mathematical Foundations 📐
 
+> **Correction notice.** Earlier versions of this document presented "golden ratio (φ)
+> optimization", "Lagrange-multiplier optimality proofs", and "Bellman equations / dynamic
+> programming for routing" as the contract's mathematics. **None of that was ever wired into
+> the production swap path** — the optimization functions (`MathLib.calculateOptimalAmount`,
+> `PoolLib.calculateOptimalSwapAmount`) had zero production callers and have been **removed**.
+> `BofhContractV2` is a **sequential constant-product (x·y=k) multi-hop executor**: the full
+> input amount flows through each hop in order, priced with the standard Uniswap-V2
+> constant-product-with-fee formula. There is **no on-chain amount-splitting, no golden-ratio
+> path optimization, no Lagrange optimizer, and no on-chain Bellman/dynamic-programming
+> router** — any path-finding or amount-sizing belongs **off-chain**, not in the executor.
+>
+> The sections below marked **(historical design note)** describe an earlier, never-shipped
+> proposal and are kept for context only. The **legitimate, real math is also retained**:
+> the constant-product formula (§1.1), the `getAmountOut`-with-fee relation, per-hop price
+> impact, and the Newton-Raphson and geometric-mean primitives (§4) genuinely back the
+> deployed code.
+
 ## Arbitrage Theory and Implementation 📚
 
 This document provides an in-depth analysis of the mathematical principles underlying the BofhContract's arbitrage and swap mechanisms.
@@ -29,9 +46,15 @@ For n connected pools, we analyze the composite function:
 f(x1, ..., xn) = ∏i (xi * yi = ki)
 ```
 
-### 2. Optimal Path Execution 🛣️
+### 2. Optimal Path Execution 🛣️ *(historical design note — NOT shipped behavior)*
 
-#### 2.1 Golden Ratio Optimization
+> ⚠️ **This entire section describes a never-shipped proposal.** The golden-ratio split,
+> the Lagrange-multiplier "proof", and the Bellman/dynamic-programming router below were
+> **never wired into production and have been removed from the code**. The deployed contract
+> does **no** on-chain path optimization; it executes a caller-supplied path hop-by-hop.
+> Retained for historical context only.
+
+#### 2.1 Golden Ratio Optimization *(historical — removed from code)*
 
 The golden ratio φ ≈ 0.618034 emerges from solving:
 ```
@@ -63,14 +86,19 @@ For 5-way paths:
 ≈ [0.381966, 0.236068, 0.145898, 0.090170, 0.145898]
 ```
 
-#### 2.2 Dynamic Programming Implementation
+#### 2.2 Dynamic Programming Implementation *(historical — never implemented on-chain)*
+
+> ⚠️ The Bellman-equation router below was **never implemented in the contract**. There is
+> no `optimizePath` / `calculateOptimalSplit` / `reconstructPath` in the deployed code; the
+> snippet is illustrative of the abandoned proposal only. Routing (which path to trade) is a
+> **caller-supplied, off-chain** decision.
 
 The Bellman equation for path optimization:
 ```
 V(s) = max_{a∈A} {R(s,a) + γV(s')}
 ```
 
-Implementation in code:
+Illustrative (never shipped) pseudo-code:
 ```solidity
 function optimizePath(
     uint256[] memory reserves,
@@ -90,21 +118,31 @@ function optimizePath(
 
 #### 3.1 Slippage Estimation
 
-Third-order Taylor expansion for price impact:
+> ⚠️ **Correction.** The contract does **not** use the "third-order Taylor / λ market-depth"
+> series shown below — that was part of the never-shipped optimization proposal. The deployed
+> price-impact check is the **exact constant-product impact** computed per hop in
+> `PoolLib.validateSwap` directly from `(reserveIn, reserveOut, amountIn)` and the per-hop
+> fee, then compared against the configured cap. The Taylor expansion is retained here only as
+> a historical note.
+
+Historical (never-shipped) third-order Taylor expansion for price impact:
 ```
 ΔP/P ≈ -λ(ΔR/R) + (λ2/2)(ΔR/R)2 - (λ3/6)(ΔR/R)3
 ```
 
-Implementation:
-```solidity
-function calculatePriceImpact(
-    uint256 amountIn,
-    uint256 reserveIn,
-    uint256 reserveOut
-) internal pure returns (uint256) {
-    // Detailed implementation
-}
+**Actual deployed model — exact CPMM (x·y=k).** For a hop with reserves
+`(reserveIn, reserveOut)`, fee `feeBps`, and input `amountIn`:
 ```
+// Output pricing — SwapMathLib.getAmountOut
+amountInWithFee = amountIn * (10000 - feeBps)
+amountOut       = (amountInWithFee * reserveOut)
+                  / (reserveIn * 10000 + amountInWithFee)
+
+// Price impact (separate) — PoolLib.calculatePriceImpact
+priceImpact     = (oldPrice - newPrice) / oldPrice, from the post-swap x·y=k reserves
+```
+The per-hop price impact is enforced against the configured cap in `PoolLib.validateSwap`;
+there is no λ / Taylor model in code.
 
 #### 3.2 Volatility Tracking
 
@@ -172,11 +210,14 @@ function optimizedSwap(
 
 #### 6.2 Computational Complexity
 
-| Algorithm         | Time Complexity | Space Complexity |
-|------------------|----------------|------------------|
-| Path optimization| O(n)           | O(1)             |
-| Price impact     | O(1)           | O(1)             |
-| Volatility calc  | O(1)           | O(1)             |
+> ⚠️ The "Path optimization" row refers to the removed/never-shipped on-chain optimizer and
+> does not describe the deployed contract (which performs no on-chain path optimization).
+
+| Algorithm                          | Time Complexity | Space Complexity |
+|------------------------------------|----------------|------------------|
+| Path optimization *(removed)*      | O(n)           | O(1)             |
+| Price impact (per-hop CPMM)        | O(1)           | O(1)             |
+| Volatility calc                    | O(1)           | O(1)             |
 
 ### 7. Future Optimizations 🔮
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -372,36 +372,29 @@ Attackers manipulate pool prices to exploit price-dependent systems:
 
 **1. Price Impact Validation** (PoolLib.sol:120-150)
 ```solidity
-function calculatePriceImpact(
-    uint256 reserveIn,
-    uint256 reserveOut,
-    uint256 amountIn
-) internal pure returns (uint256 impact) {
-    // Third-order Taylor expansion for CPMM price impact
-    // ΔP/P = -λ(ΔR/R) + (λ²/2)(ΔR/R)² - (λ³/6)(ΔR/R)³
-
-    uint256 lambda = (amountIn * PRECISION) / reserveIn;
-    uint256 lambdaSquared = (lambda * lambda) / PRECISION;
-    uint256 lambdaCubed = (lambdaSquared * lambda) / PRECISION;
-
-    uint256 firstOrder = lambda;
-    uint256 secondOrder = lambdaSquared / 2;
-    uint256 thirdOrder = lambdaCubed / 6;
-
-    impact = firstOrder + secondOrder + thirdOrder;
-
-    return impact;
+// EXACT constant-product (x·y=k) marginal-price deviation — NOT a Taylor approximation.
+function calculatePriceImpact(uint256 amountIn, PoolState memory pool)
+    internal pure returns (uint256)
+{
+    if (amountIn == 0) return 0;
+    uint256 k             = pool.reserveIn * pool.reserveOut;
+    uint256 newReserveIn  = pool.reserveIn + amountIn;
+    uint256 newReserveOut = k / newReserveIn;              // exact post-swap reserves
+    uint256 oldPrice      = (pool.reserveOut * PRECISION) / pool.reserveIn;
+    uint256 newPrice      = (newReserveOut * PRECISION) / newReserveIn;
+    if (newPrice >= oldPrice) return 0;
+    return ((oldPrice - newPrice) * PRECISION) / oldPrice; // PRECISION-scaled deviation
 }
 ```
 
 **2. Liquidity Thresholds** (PoolLib.sol:53-55)
 ```solidity
-uint256 poolLiquidity = MathLib.geometricMean(reserveIn, reserveOut);
-if (poolLiquidity < minLiquidity) revert InsufficientLiquidity();
+// PoolLib enforces a raw reserve floor (the MathLib.geometricMean helper was removed)
+if (reserveIn < MIN_POOL_LIQUIDITY || reserveOut < MIN_POOL_LIQUIDITY) revert InsufficientLiquidity();
 ```
 - Prevents swaps in low-liquidity pools (easily manipulated)
-- Default `minPoolLiquidity = 100 * PRECISION`
-- Geometric mean: √(reserveIn × reserveOut) provides accurate liquidity measure
+- Enforced floor is `PoolLib.MIN_POOL_LIQUIDITY` (raw reserve units). Note: the contract-level
+  `minPoolLiquidity` risk parameter is currently NOT enforced in the swap path (see audit notes)
 
 **3. Maximum Trade Size** (PoolLib.sol:66-68)
 ```solidity
@@ -1215,7 +1208,7 @@ REPORT_GAS=true npm test
 
 **Critical Libraries to Review:**
 1. `SecurityLib` - Reentrancy guards, access control, MEV protection
-2. `MathLib` - Newton's method, golden ratio calculations
+2. `MathLib` - Newton's method (sqrt/cbrt), fixed-point exp2/log2
 3. `PoolLib` - Price impact, liquidity analysis
 
 **Edge Cases to Test:**

--- a/docs/SECURITY_CHECKLIST.md
+++ b/docs/SECURITY_CHECKLIST.md
@@ -273,29 +273,22 @@ modifier antiMEV() {
 | Multiple price source validation | ❌ Missing | Single source (pool reserves) | - |
 | Price deviation checks | ✅ Complete | Price impact limits | PoolLib.sol:120-150 |
 | Liquidity threshold requirements | ✅ Complete | Minimum pool liquidity checks | PoolLib.sol:53-55 |
-| Large trade impact analysis | ✅ Complete | Third-order Taylor expansion | PoolLib.sol:120-150 |
+| Large trade impact analysis | ✅ Complete | Exact constant-product (x·y=k) marginal-price deviation | PoolLib.calculatePriceImpact |
 
 **Current Price Impact Calculation** (PoolLib.sol:120-150):
 ```solidity
-function calculatePriceImpact(
-    uint256 reserveIn,
-    uint256 reserveOut,
-    uint256 amountIn
-) internal pure returns (uint256 impact) {
-    // CPMM third-order Taylor expansion
-    // ΔP/P = -λ(ΔR/R) + (λ²/2)(ΔR/R)² - (λ³/6)(ΔR/R)³
-
-    uint256 lambda = (amountIn * PRECISION) / reserveIn;
-    uint256 lambdaSquared = (lambda * lambda) / PRECISION;
-    uint256 lambdaCubed = (lambdaSquared * lambda) / PRECISION;
-
-    uint256 firstOrder = lambda;
-    uint256 secondOrder = lambdaSquared / 2;
-    uint256 thirdOrder = lambdaCubed / 6;
-
-    impact = firstOrder + secondOrder + thirdOrder;
-
-    return impact;
+// EXACT constant-product (x·y=k) marginal-price deviation — NOT a Taylor approximation.
+function calculatePriceImpact(uint256 amountIn, PoolState memory pool)
+    internal pure returns (uint256)
+{
+    if (amountIn == 0) return 0;
+    uint256 k             = pool.reserveIn * pool.reserveOut;
+    uint256 newReserveIn  = pool.reserveIn + amountIn;
+    uint256 newReserveOut = k / newReserveIn;
+    uint256 oldPrice      = (pool.reserveOut * PRECISION) / pool.reserveIn;
+    uint256 newPrice      = (newReserveOut * PRECISION) / newReserveIn;
+    if (newPrice >= oldPrice) return 0;
+    return ((oldPrice - newPrice) * PRECISION) / oldPrice;
 }
 ```
 

--- a/docs/STRATEGY_AND_REALITY.md
+++ b/docs/STRATEGY_AND_REALITY.md
@@ -87,6 +87,20 @@ The research is unambiguous: **every measured on-chain extraction market in 2025
 - **Retail sniping (#8)** is directional speculation, not market-neutral extraction. >60% of participants lose. Copy-trading makes you a KOL's exit liquidity. The tooling layer is saturated by funded incumbents.
 - **OEV / liquidations (#2, #3)** are genuinely permissionless and winnable on bid-math — but Chainlink SVR liquidation recapture is already **>80% with many onboarded searchers** (late and crowded), and in these venues you bid *into someone else's ordering* via EIP-712 bundles, so **our executor contributes nothing to the win condition.** Good hedge, bad reason to keep the contract.
 
+> **Sources / caveat.** The specific figures in §3 — e.g. "$233.8M CEX-DEX extracted
+> Aug-2023→Mar-2025", "top 3 searchers ~90%", "~130M gas / ~350 failed txs per arb",
+> "BSC ~80%+ two builders", "Base ~2 entities >80% of blocks", "independent searchers
+> retain ~17%", "Chainlink SVR recapture >80%", "JIT V3 ~0.007% ROI", "cross-chain ~67%
+> pre-positioned inventory / >50% from 5 addresses" — are **directional figures drawn from
+> public 2024–2025 MEV research**, not first-party measurements. Source types include the
+> **Flashbots research/transparency materials** ("limits of scaling" / blind-search
+> efficiency), **public MEV dashboards and explorers** (e.g. EigenPhi-style CEX-DEX/arb
+> analytics, builder/relay market-share trackers), **Chainlink SVR program reporting**, and
+> **academic / industry cross-chain-MEV studies**. They are used here only to rank strategy
+> attractiveness and should be **re-verified against current primary sources before any
+> capital or audit decision** — exact magnitudes drift quarter-to-quarter and no URL is
+> pinned on purpose to avoid implying a precision the figures don't have.
+
 ### Why #1 is the call
 
 **Long-tail / fresh-launch V2-fork backrunning** is the only strategy that satisfies all three conditions at once:
@@ -142,7 +156,7 @@ It reports: **net profit/opportunity, opportunities/day, gross-vs-net spread, wi
 **KILL the project if, on the best target chain over a representative window, ANY of:**
 
 1. Median **net-of-gas profit/opportunity < 2-3× total frictions** (fees + gas + bribe).
-2. Realistic **win-rate so low that expected daily net < infra + capital cost.**
+2. Realistic **win-rate so low that expected daily net < infra cost** (`infraCostUsdPerDay`). *(Capital cost is not yet modeled in `backtester.js`; the implemented check — KILL(2) — compares expected daily net against `infraCostUsdPerDay` only. Folding in a capital-carry term is a tracked TODO.)*
 3. The edge exists **only for a lean Huff executor**, never for a realistic executor at our gas profile — meaning we'd have to win the rewrite arms race just to break even.
 4. **Revert/loss rate** lands in the bad regime (the literature shows 5-40% daily revert on fast-finality rollups; honeypots compound this) and wipes expected value.
 
@@ -172,7 +186,7 @@ We do not strip the contract for production until the edge is proven. We do not 
 Proceed only when **all** hold on the best target chain over a representative window:
 
 - Median net-of-gas profit/opportunity **≥ 2-3× total frictions**, sustained.
-- Live-shadow **win-rate × opportunities/day** yields **expected daily net > infra + capital cost** with margin.
+- Live-shadow **win-rate × opportunities/day** yields **expected daily net > infra cost** (`infraCostUsdPerDay`, as enforced by KILL(2)) with margin. *(Capital-carry cost is not yet in the model — a tracked TODO; fold it in before treating this bar as complete.)*
 - Profitable at a **realistic (not Huff-only) executor gas profile** — i.e., a modest gas trim makes it work; we don't need to win a Huff arms race to break even.
 - **Revert/honeypot loss rate** controlled by the token-safety guard to a level that doesn't wipe EV.
 - Backtest survives the hygiene haircuts (2× slippage, latency, live-Sharpe −1) and is **not** in the Sharpe>3 overfit zone.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -74,8 +74,8 @@ function swap(address tokenIn, uint256 amountIn) { }
 #### Constants
 ```solidity
 // UPPER_SNAKE_CASE
-uint256 private constant GOLDEN_RATIO = 618034;
-uint256 public constant MAX_PATH_LENGTH = 5;
+uint256 private constant MAX_FEE_BPS = 1000;
+uint256 public constant MAX_PATH_LENGTH = 6;
 uint256 internal constant PRECISION = 1e6;
 ```
 
@@ -575,12 +575,12 @@ def execute_swap(path, amount):
 
 ### Examples
 ```
-feat(swap): add multi-path swap optimization
+feat(swap): add multi-DEX routing via per-hop dexId registry
 
-Implement golden ratio-based distribution for 4-way and 5-way swaps
-to minimize price impact across multiple paths.
+Resolve each hop's factory + fee from an owner-managed registry so one
+deployment can route a path across multiple V2 forks.
 
-Closes #42
+Closes #NN
 ```
 
 ```

--- a/research/backtester.js
+++ b/research/backtester.js
@@ -23,6 +23,7 @@
  * The kill-criteria are deliberately strict and explicit so a GO is earned, not assumed.
  */
 
+const { ethers } = require('ethers');
 const { getAmountOut } = require('./pathfinder.js');
 const { gasCostForCycle, compareExecutors } = require('./gasModel.js');
 
@@ -117,12 +118,18 @@ function optimalInput(hops, opts = {}) {
 /**
  * Convert a wei base-token amount to USD using the native-token USD price as a proxy.
  * (TODO: real per-token USD; for a wrapped-native base token this proxy is exact.)
- * @param {bigint} wei
+ *
+ * PRECISION: `wei` can exceed Number.MAX_SAFE_INTEGER (2^53 ≈ 9.0e15 wei), so a naive
+ * `Number(wei)` would silently lose precision and corrupt the USD/PnL figure. We instead
+ * format the bigint to a decimal *string* of whole tokens via ethers (scaling down by 1e18
+ * exactly, in bigint) and only then convert that already-small magnitude to Number.
+ * @param {bigint} wei - may be negative (e.g. a net loss).
  * @param {number} nativeUsdPrice
  * @returns {number}
  */
 function weiToUsd(wei, nativeUsdPrice) {
-  return (Number(wei) / 1e18) * Number(nativeUsdPrice || 0);
+  const tokens = Number(ethers.formatUnits(BigInt(wei), 18));
+  return tokens * Number(nativeUsdPrice || 0);
 }
 
 /**

--- a/research/config.example.json
+++ b/research/config.example.json
@@ -20,7 +20,7 @@
     "reserveBatchSize": 100,
     "minReserveBaseToken": "1.0",
     "snapshotBlockTag": "latest",
-    "snapshotOutPath": "research/data/snapshot.latest.json"
+    "snapshotOutPath": "research/data/snapshot.json"
   },
 
   "pathfinder": {

--- a/research/gasModel.js
+++ b/research/gasModel.js
@@ -20,6 +20,8 @@
  * for measurements.
  */
 
+const { ethers } = require('ethers');
+
 // Gas profiles: { baseGas, perHopGas }. Total = baseGas + perHopGas * hops, where
 // `hops` = number of swaps in the cycle = path.length - 1.
 const EXECUTOR_PROFILES = {
@@ -82,7 +84,9 @@ function gasCostForCycle(hops, gasCfg, executor = 'bofhV2') {
   const gasUnits = estimateGasUnits(hops, executor);
   const gasPriceWei = effectiveGasPriceWei(gasCfg);
   const costWei = BigInt(gasUnits) * BigInt(gasPriceWei);
-  const costNative = Number(costWei) / 1e18;
+  // PRECISION: costWei can exceed 2^53, so scale the bigint down by 1e18 exactly (as a
+  // decimal string via ethers) before converting to Number, instead of Number(costWei)/1e18.
+  const costNative = Number(ethers.formatEther(costWei));
   const nativeUsd = Number(gasCfg.nativeUsdPrice || 0);
   const costUsd = costNative * nativeUsd;
   return { gasUnits, gasPriceWei, costWei, costNative, costUsd, executor };

--- a/research/scanner.js
+++ b/research/scanner.js
@@ -255,7 +255,11 @@ async function main() {
     if (!snapshot) continue;
 
     const base = (config.scan && config.scan.snapshotOutPath) || 'research/data/snapshot.json';
-    const outPath = base.replace(/snapshot/, `snapshot.${chain.key}`);
+    // Canonical per-chain filename: snapshot.<chain>.json. Inject `.<chain>` right before
+    // the final extension so the result is deterministic regardless of the configured base
+    // (e.g. ".../snapshot.json" -> ".../snapshot.bsc.json"). Documented in research/README.md.
+    const ext = path.extname(base);
+    const outPath = `${base.slice(0, base.length - ext.length)}.${chain.key}${ext}`;
     const written = writeSnapshot(snapshot, outPath);
     console.log(
       `[scanner] ${chain.key}: ${snapshot.pools.length} pools @ block ${snapshot.blockNumber} -> ${written}`


### PR DESCRIPTION
Completes the **restore-reality** pass (the review of the prior cleanup flagged residual false claims in audit/security docs) and fixes the **research-toolkit nits**.

## Docs — stop asserting removed mechanics as CURRENT behavior
- **`AUDIT_PREPARATION.md`** (auditor-facing): corrected the feature list, the "Critical Mathematical Components" (golden-ratio + third-order Taylor → real shared CPMM `getAmountOut` + exact x·y=k price impact), the MathLib function list, the overview line, and the constants snippet (removed `GOLDEN_RATIO`, fixed `MAX_PATH_LENGTH` 5→6, added `MAX_FEE_BPS`).
- **`SECURITY.md` + `SECURITY_CHECKLIST.md`**: replaced the **fictional "third-order Taylor / λ" price-impact code** with the actual `PoolLib.calculatePriceImpact` (exact x·y=k marginal-price deviation); fixed the `geometricMean` liquidity snippet and the "MathLib — golden ratio calculations" line.
- **`MATHEMATICAL_FOUNDATIONS.md` + `README.md`**: clarified **output pricing** (`SwapMathLib.getAmountOut`) vs the **separate** price-impact calc (`PoolLib.calculatePriceImpact`).
- **`STYLE_GUIDE.md`**: replaced golden-ratio examples with real ones; `MAX_PATH_LENGTH` 5→6.
- `SWAP_ALGORITHMS.md` already carries a strong top correction notice over its historical body; the gas-optimization retrospectives are left as dated historical records.

## Research toolkit nits (from the #43 review)
- Snapshot filename made consistent (`snapshot.<chain>.json` across scanner/run/README/.gitignore).
- Precision: `weiToUsd` / gas `costNative` now use ethers `formatUnits`/`formatEther` (no `Number(bigint)` loss above 2^53).
- GO/KILL label aligned to the implemented infra-cost check (capital-carry noted as a TODO).
- `STRATEGY_AND_REALITY.md`: added a **sources/caveat** note for the web-sourced MEV figures.

## Verification
- Full suite **326 passing / 0 failing** (docs/research only — no contract change) · `node --check` on `research/*.js` · `node research/run.js --demo` runs end-to-end.