### PR TITLE
feat(solver): Atlas/FastLane backrun solver leg (2026 play #1)

### DIFF
--- a/contracts/mocks/MockAtlas.sol
+++ b/contracts/mocks/MockAtlas.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import "../solvers/IAtlasSolver.sol";
+import "../interfaces/ISwapInterfaces.sol";
+
+/// @title MockAtlas - minimal Atlas escrow/callback stand-in for solver integration tests
+/// @author Bofh Team
+/// @notice A deliberately tiny model of the Atlas metacall: it plays the role of the Atlas
+/// @notice contract (the only address allowed to call {ISolverContract.atlasSolverCall}) and the
+/// @notice Execution Environment (the address the bid is paid to), and exposes the
+/// @notice {IAtlasEscrow.shortfall}/{IAtlasEscrow.reconcile} handshake so the solver's gas-debt
+/// @notice settlement path is exercised. It is NOT a faithful Atlas — it captures only the slice
+/// @notice the {BofhAtlasSolver} touches, so tests can run atlasSolverCall end-to-end against the
+/// @notice existing MockFactory/MockPair/MockToken stack.
+/// @dev The mock asserts the BLIND-BID invariant for the test: after invoking the solver it checks
+/// @dev that the Execution Environment actually received `bidAmount` of the bid token. If the
+/// @dev solver reverts (unprofitable / under-min / unauthorized), this whole metacall reverts and
+/// @dev the mock observes nothing was paid — matching Atlas skipping a non-paying solver.
+contract MockAtlas is IAtlasEscrow {
+    /// @notice The Execution Environment the bid must be paid to (here: this contract itself,
+    /// @notice unless overridden) so the mock can assert receipt.
+    address public executionEnvironment;
+
+    /// @notice Configurable native gas shortfall the solver is expected to reconcile (0 by default
+    /// @notice so the ERC20-only happy path doesn't require funding the solver with native value).
+    uint256 public reportedShortfall;
+
+    /// @notice How much native value the solver actually reconciled in the last metacall.
+    uint256 public lastReconciled;
+
+    /// @notice Records the bid-token balance the EE held before the last metacall (for assertions).
+    uint256 public eeBalanceBefore;
+
+    /// @notice Emitted after a successful metacall so tests can assert on the settled bid.
+    event MetacallSettled(
+        address indexed solver,
+        address indexed bidToken,
+        uint256 bidAmount,
+        uint256 bidReceivedByEE
+    );
+
+    /// @notice Thrown when, after the solver runs, the EE did not receive the committed bid.
+    error BidNotPaid(uint256 received, uint256 expected);
+
+    constructor() {
+        executionEnvironment = address(this);
+    }
+
+    /// @notice Override the EE address (defaults to this contract) for tests that want a separate
+    /// @notice EE sink. The bid receipt assertion uses whatever EE is set here.
+    function setExecutionEnvironment(address ee) external {
+        executionEnvironment = ee;
+    }
+
+    /// @notice Configure a native gas shortfall the solver should reconcile() this metacall.
+    function setShortfall(uint256 amount) external {
+        reportedShortfall = amount;
+    }
+
+    /// @inheritdoc IAtlasEscrow
+    function shortfall() external view override returns (uint256) {
+        return reportedShortfall;
+    }
+
+    /// @inheritdoc IAtlasEscrow
+    /// @dev Accepts the solver's native repayment and records it. Returns remaining owed.
+    function reconcile(uint256 maxApprovedGasSpend) external payable override returns (uint256 owed) {
+        lastReconciled += msg.value;
+        uint256 paid = maxApprovedGasSpend < msg.value ? maxApprovedGasSpend : msg.value;
+        owed = reportedShortfall > paid ? reportedShortfall - paid : 0;
+        reportedShortfall = owed;
+        return owed;
+    }
+
+    /// @notice Drive one Atlas-style metacall: invoke the solver with a winning bid and assert the
+    /// @notice Execution Environment received the committed bid afterward (the blind-bid invariant).
+    /// @dev This is the entry tests call. It mirrors Atlas selecting the top bid and calling the
+    /// @dev solver contract; the post-call bid-receipt check stands in for Atlas's ex-post
+    /// @dev accounting. Any revert inside the solver bubbles up (metacall fails, nothing settled).
+    /// @param solver The BofhAtlasSolver contract to invoke
+    /// @param solverOpFrom The searcher EOA that signed the SolverOperation
+    /// @param bidToken Token the bid is denominated in (must be the solver's base token here)
+    /// @param bidAmount Amount of bidToken the solver committed to pay
+    /// @param solverOpData The encoded Backrun (abi.encode of BofhAtlasSolver.Backrun)
+    /// @return bidReceived How much bidToken the EE actually received from the solver
+    function metacall(
+        address solver,
+        address solverOpFrom,
+        address bidToken,
+        uint256 bidAmount,
+        bytes calldata solverOpData
+    ) external returns (uint256 bidReceived) {
+        address ee = executionEnvironment;
+        eeBalanceBefore = IBEP20(bidToken).balanceOf(ee);
+
+        // Invoke the solver exactly as Atlas would. Forward no native value on the happy path; a
+        // shortfall test funds the solver directly and sets reportedShortfall.
+        ISolverContract(solver).atlasSolverCall(
+            solverOpFrom,
+            ee,
+            bidToken,
+            bidAmount,
+            solverOpData,
+            bytes("") // extraReturnData (no prior phase output in the mock)
+        );
+
+        // Blind-bid invariant: the EE must have received exactly the committed bid.
+        uint256 after_ = IBEP20(bidToken).balanceOf(ee);
+        bidReceived = after_ - eeBalanceBefore;
+        if (bidReceived < bidAmount) revert BidNotPaid(bidReceived, bidAmount);
+
+        emit MetacallSettled(solver, bidToken, bidAmount, bidReceived);
+        return bidReceived;
+    }
+
+    /// @notice Allow the mock EE to hold native value for reconcile flows.
+    receive() external payable {}
+}

--- a/contracts/mocks/MockSolverExecutor.sol
+++ b/contracts/mocks/MockSolverExecutor.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import "../interfaces/ISwapInterfaces.sol";
+import "../libs/SwapMathLib.sol";
+
+/// @title MockSolverExecutor - a controllable executor stand-in for BofhAtlasSolver unit tests
+/// @author Bofh Team
+/// @notice Implements ONLY the {executeSwapMultiDex} surface BofhAtlasSolver drives, but returns a
+/// @notice caller-configured `grossOut` instead of running a real round-trip. This lets a test
+/// @notice DECOUPLE the solver's own profit guard from the real executor's `minAmountOut` backstop:
+/// @notice the solver forces `enforcedMin = max(minAmountOut, amountIn + bidAmount)`, so the REAL
+/// @notice BofhContractV2 would revert `InsufficientOutput` before the solver's `BidNotCovered`
+/// @notice branch could ever run. By IGNORING minAmountOut here and handing back an arbitrary
+/// @notice `grossOut`, the mock makes the solver-level checks (`grossOut < amountIn` and
+/// @notice `profit < bidAmount`) reachable and individually exercisable.
+/// @dev Token flow mirrors the real executor's non-custodial contract: it pulls exactly `amountIn`
+/// @dev of base from the caller (the solver, which approved it) and then transfers `grossOut` base
+/// @dev back to the caller — the same net movement the solver observes from BofhContractV2.
+/// @dev TEST-ONLY. Never deployed to a live network.
+contract MockSolverExecutor {
+    /// @notice Base token this mock pulls and returns (matches the solver's baseToken).
+    address public base;
+
+    /// @notice The exact output the next {executeSwapMultiDex} hands back, regardless of minAmountOut.
+    uint256 public nextGrossOut;
+
+    /// @notice When true, the mock honors `minAmountOut` (reverts if grossOut < min) like the real
+    /// @notice executor; when false (default) it ignores it so the solver-level guards are isolated.
+    bool public enforceMin;
+
+    error InsufficientOutput();
+
+    constructor(address base_) {
+        base = base_;
+    }
+
+    /// @notice Set the gross output the next call returns to the solver.
+    function setNextGrossOut(uint256 grossOut_) external {
+        nextGrossOut = grossOut_;
+    }
+
+    /// @notice Toggle whether the mock enforces minAmountOut (default false to isolate solver checks).
+    function setEnforceMin(bool on) external {
+        enforceMin = on;
+    }
+
+    /// @notice Same selector/signature as BofhContractV2.executeSwapMultiDex.
+    /// @dev Pulls `amountIn` base from msg.sender (the solver, which approved this contract), then
+    /// @dev sends back the pre-configured `nextGrossOut` base. The path/fees/dexIds are ignored.
+    function executeSwapMultiDex(
+        address[] calldata /* path */,
+        uint256[] calldata /* fees */,
+        uint16[] calldata /* dexIds */,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 /* deadline */
+    ) external returns (uint256) {
+        uint256 grossOut = nextGrossOut;
+        if (enforceMin && grossOut < minAmountOut) revert InsufficientOutput();
+
+        // Pull the principal exactly as the real executor does (solver approved amountIn). Uses the
+        // same tolerant safe-transfer helper as BofhContractV2 so non-standard (no-return) base
+        // tokens behave identically here.
+        SwapMathLib.safeTransferFrom(base, msg.sender, address(this), amountIn);
+
+        // Hand the configured round-trip output back to the solver (caller).
+        SwapMathLib.safeTransfer(base, msg.sender, grossOut);
+        return grossOut;
+    }
+
+    /// @notice Let tests seed this mock with base liquidity so it can return grossOut > amountIn.
+    receive() external payable {}
+}

--- a/contracts/solvers/BofhAtlasSolver.sol
+++ b/contracts/solvers/BofhAtlasSolver.sol
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+import "./IAtlasSolver.sol";
+import "../interfaces/ISwapInterfaces.sol";
+import "../interfaces/IBofhContract.sol";
+import "../libs/SwapMathLib.sol";
+
+/// @title IBofhContractV2 - the single executor entrypoint this solver drives
+/// @notice Minimal view of BofhContractV2 the solver calls. Declared at file scope (Solidity
+/// @notice forbids nested interface declarations) so the solver depends only on the one method it
+/// @notice actually uses, keeping the coupling surface explicit and small.
+interface IBofhContractV2 {
+    function executeSwapMultiDex(
+        address[] calldata path,
+        uint256[] calldata fees,
+        uint16[] calldata dexIds,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        uint256 deadline
+    ) external returns (uint256);
+}
+
+/// @title BofhAtlasSolver - Atlas/FastLane solver leg that settles a backrun via BofhContractV2
+/// @author Bofh Team
+/// @notice A thin, non-custodial SOLVER CONTRACT for the Atlas (FastLane) sealed-bid backrun OFA.
+/// @notice When Atlas calls {atlasSolverCall} with the winning bid, this contract decodes a
+/// @notice multi-DEX backrun (path/fees/dexIds/amountIn/minAmountOut), executes it through the
+/// @notice already-audited {IBofhContractV2.executeSwapMultiDex} settlement leg, repays the Atlas
+/// @notice escrow shortfall, hands the committed bid to the Execution Environment, and forwards
+/// @notice any surplus to the configured beneficiary. The executor stays the COMMODITY; the only
+/// @notice value this contract adds is gluing that commodity to the Atlas auction handshake.
+/// @dev DESIGN: this contract holds NO long-lived inventory. It pulls exactly `amountIn` of the
+/// @dev base token from the funding source for the duration of the metacall, swaps it, and the
+/// @dev base token returns to this contract as the swap output. From that output it (a) pays the
+/// @dev bid to the executionEnvironment and (b) sweeps the remainder to `beneficiary`. If the
+/// @dev round-trip does not clear minAmountOut OR cannot cover the bid, it REVERTS — which is the
+/// @dev correct signal under Atlas's ex-post blind accounting (the auction simply skips this
+/// @dev solver and settles the next-best bid; nothing is half-applied).
+/// @custom:security onlyOwner config; atlasSolverCall gated to the registered Atlas + searcher.
+/// @custom:noncustodial Inventory is pulled per-call and never parked here between metacalls.
+///
+/// @dev ====================================================================================
+/// @dev  ██  GATE-0 — DO NOT DEPLOY / BOND / PAY FOR AUDIT UNTIL BOTH HOLD  ██
+/// @dev ------------------------------------------------------------------------------------
+/// @dev  (a) PERMISSIONLESS OFA STILL OPEN: Chainlink ACQUIRED Atlas on 22 Jan 2026 and pivoted
+/// @dev      toward SVR-liquidation flow. Verify LIVE, against the target chain's actual Atlas
+/// @dev      deployment, that an outside searcher can still register a SolverOperation and win a
+/// @dev      permissionless DEX backrun (no Chainlink-gated allowlist). If the DEX-backrun OFA is
+/// @dev      closed/allowlisted, this whole play is dead — do not spend on an audit.
+/// @dev  (b) EDGE PROVEN ON REAL DATA: research/backtester.js must show net-of-gas GO (not KILL)
+/// @dev      on REAL captured opportunities for the target chain/pairs BEFORE bonding capital.
+/// @dev
+/// @dev  Until (a) AND (b) are signed off, this contract is a SPEC + TEST HARNESS only.
+/// @dev  TODO(real-deps): wire IAtlasEscrow to the live Atlas address; confirm the exact
+/// @dev  bid-settlement convention (reconcile vs. direct transfer to executionEnvironment) against
+/// @dev  the pinned Atlas release on the target chain — the docs evolved across Atlas versions.
+/// @dev ====================================================================================
+contract BofhAtlasSolver is ISolverContract {
+    // ----------------------------------------------------------------------------------------
+    // Storage
+    // ----------------------------------------------------------------------------------------
+
+    /// @notice Owner / admin (set at deploy; the only address allowed to (re)configure the solver)
+    address public owner;
+
+    /// @notice The Atlas contract permitted to invoke {atlasSolverCall}. Calls from anyone else
+    /// @notice revert. Set by the owner once the live Atlas address is GATE-0-verified.
+    address public atlas;
+
+    /// @notice The searcher EOA whose signed SolverOperations this contract is willing to run.
+    /// @notice address(0) means "not yet configured" => atlasSolverCall reverts. Pinning this
+    /// @notice prevents a griefing op (signed by some other searcher but pointing `solver` here)
+    /// @notice from making this contract perform work / leak value.
+    address public authorizedSearcher;
+
+    /// @notice The deployed BofhContractV2 multi-DEX executor that settles the backrun.
+    address public executor;
+
+    /// @notice The base token (e.g. WBNB/WETH) the executor round-trips. All backruns start and
+    /// @notice end in this token; the bid is paid in it and the surplus is swept in it.
+    address public baseToken;
+
+    /// @notice Where post-bid surplus (the realized arbitrage profit) is swept after each win.
+    address public beneficiary;
+
+    /// @notice Reentrancy lock for {atlasSolverCall}. The executor it calls is already nonReentrant,
+    /// @notice but this guards the NEW external surface (settlement + native reconcile()) on its own,
+    /// @notice so a malicious bid/execution-environment/escrow cannot re-enter mid-settlement. A plain
+    /// @notice bool is the cheapest defense-in-depth here (single SSTORE set/clear per call).
+    bool private _locked;
+
+    // ----------------------------------------------------------------------------------------
+    // Events
+    // ----------------------------------------------------------------------------------------
+
+    /// @notice Emitted when the owner (re)points the solver at an executor/base token.
+    event ExecutorConfigured(address indexed executor, address indexed baseToken);
+
+    /// @notice Emitted when the owner sets the Atlas address + authorized searcher EOA.
+    event AtlasConfigured(address indexed atlas, address indexed authorizedSearcher);
+
+    /// @notice Emitted when the beneficiary (surplus sink) is updated.
+    event BeneficiaryUpdated(address indexed beneficiary);
+
+    /// @notice Emitted on a settled backrun.
+    /// @param executionEnvironment The Atlas EE the bid was paid to
+    /// @param bidToken Token the bid was denominated in
+    /// @param bidAmount Bid amount paid to the EE
+    /// @param grossOut Total base-token output from the round-trip
+    /// @param surplus Amount swept to the beneficiary after paying the bid
+    event BackrunSettled(
+        address indexed executionEnvironment,
+        address indexed bidToken,
+        uint256 bidAmount,
+        uint256 grossOut,
+        uint256 surplus
+    );
+
+    // ----------------------------------------------------------------------------------------
+    // Errors
+    // ----------------------------------------------------------------------------------------
+
+    /// @notice Thrown when a privileged call is made by a non-owner.
+    error NotOwner();
+    /// @notice Thrown when atlasSolverCall is invoked by anyone other than the configured Atlas.
+    error NotAtlas();
+    /// @notice Thrown when the signing searcher is not the configured authorizedSearcher.
+    error UnauthorizedSearcher();
+    /// @notice Thrown when the solver has not been fully configured before a call.
+    error NotConfigured();
+    /// @notice Thrown on a zero address where a real address is required.
+    error ZeroAddress();
+    /// @notice Thrown when the bid is denominated in a token this solver cannot settle (only the
+    /// @notice base token is supported — the round-trip produces base token, nothing else).
+    error UnsupportedBidToken();
+    /// @notice Thrown when the realized PROFIT (output minus principal) cannot cover the committed
+    /// @notice bid — i.e. the backrun is not profitable enough to pay the bid without eating the
+    /// @notice solver's own working float. Reverting here keeps Atlas blind-bid accounting honest.
+    /// @param available The profit (or output) available to cover the bid
+    /// @param bidAmount The bid the solver committed to pay
+    error BidNotCovered(uint256 available, uint256 bidAmount);
+    /// @notice Thrown when {atlasSolverCall} is re-entered before the in-flight settlement completes.
+    error Reentrancy();
+
+    // ----------------------------------------------------------------------------------------
+    // Modifiers
+    // ----------------------------------------------------------------------------------------
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    /// @notice Minimal reentrancy guard for {atlasSolverCall}. Defense-in-depth on the new external
+    /// @notice surface: the bid transfer, native reconcile(), and surplus sweep all touch addresses
+    /// @notice (executionEnvironment / atlas escrow / beneficiary) that could attempt to re-enter.
+    modifier nonReentrant() {
+        if (_locked) revert Reentrancy();
+        _locked = true;
+        _;
+        _locked = false;
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Construction / configuration (owner-only)
+    // ----------------------------------------------------------------------------------------
+
+    /// @notice Deploy with the owner set to the deployer; everything else is configured post-deploy
+    /// @notice so the live, GATE-0-verified Atlas address can be wired in deliberately (not baked
+    /// @notice into bytecode before the OFA's openness is confirmed).
+    constructor() {
+        owner = msg.sender;
+        beneficiary = msg.sender;
+    }
+
+    /// @notice Point the solver at the deployed BofhContractV2 executor and its base token.
+    /// @dev The executor and base token must agree (the executor's immutable baseToken). We keep
+    /// @dev baseToken explicit here so the solver never reads it cross-contract on the hot path.
+    /// @param executor_ The deployed BofhContractV2 address
+    /// @param baseToken_ The executor's base token (WBNB/WETH/...)
+    function configureExecutor(address executor_, address baseToken_) external onlyOwner {
+        if (executor_ == address(0) || baseToken_ == address(0)) revert ZeroAddress();
+        executor = executor_;
+        baseToken = baseToken_;
+        emit ExecutorConfigured(executor_, baseToken_);
+    }
+
+    /// @notice Set the Atlas contract and the searcher EOA this solver will run for.
+    /// @dev GATE-0: only call this with an Atlas address whose permissionless DEX-backrun OFA has
+    /// @dev been verified still open post-Chainlink-acquisition.
+    /// @param atlas_ The Atlas contract permitted to call atlasSolverCall
+    /// @param authorizedSearcher_ The searcher EOA whose signed SolverOperations are honored
+    function configureAtlas(address atlas_, address authorizedSearcher_) external onlyOwner {
+        if (atlas_ == address(0) || authorizedSearcher_ == address(0)) revert ZeroAddress();
+        atlas = atlas_;
+        authorizedSearcher = authorizedSearcher_;
+        emit AtlasConfigured(atlas_, authorizedSearcher_);
+    }
+
+    /// @notice Update where realized surplus is swept after each settled backrun.
+    /// @param beneficiary_ New surplus sink (must be non-zero)
+    function setBeneficiary(address beneficiary_) external onlyOwner {
+        if (beneficiary_ == address(0)) revert ZeroAddress();
+        beneficiary = beneficiary_;
+        emit BeneficiaryUpdated(beneficiary_);
+    }
+
+    /// @notice Transfer ownership of the solver config surface.
+    /// @param newOwner The new owner (must be non-zero)
+    function transferOwnership(address newOwner) external onlyOwner {
+        if (newOwner == address(0)) revert ZeroAddress();
+        owner = newOwner;
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // Atlas solver entrypoint
+    // ----------------------------------------------------------------------------------------
+
+    /// @notice The ABI of the backrun this solver decodes out of {SolverOperation.data}.
+    /// @dev The off-chain searcher encodes exactly these fields (abi.encode) into solverOpData.
+    /// @dev fees/dexIds parallel the hops; amountIn is the base-token notional the round-trip
+    /// @dev borrows from this contract's balance during the metacall.
+    struct Backrun {
+        address[] path;
+        uint256[] fees;
+        uint16[] dexIds;
+        uint256 amountIn;
+        uint256 minAmountOut;
+        uint256 deadline;
+    }
+
+    /// @inheritdoc ISolverContract
+    /// @dev Flow (mirrors the FastLane SolverBase contract, adapted to settle via BofhContractV2):
+    /// @dev   1. authZ: msg.sender == atlas, solverOpFrom == authorizedSearcher, fully configured;
+    /// @dev   2. bid sanity: only base-token (or native==base proxy) bids are settleable here;
+    /// @dev   3. decode the Backrun from solverOpData and run executor.executeSwapMultiDex, which
+    /// @dev      pulls amountIn from THIS contract, round-trips it, and returns base token here.
+    /// @dev      We force the executor min to >= amountIn + bidAmount (principal + bid) so a
+    /// @dev      successful swap structurally preserves principal AND covers the bid (re-checked
+    /// @dev      after as defense-in-depth: profit = grossOut - amountIn must be >= bidAmount);
+    /// @dev   4. settle: pay `bidAmount` of bidToken to the executionEnvironment so Atlas's ex-post
+    /// @dev      accounting nets out; reconcile any Atlas gas shortfall when present;
+    /// @dev   5. sweep the POST-BID PROFIT to `beneficiary` (the principal float stays in-contract).
+    /// @dev Any failure in 2-4 reverts the whole call -> Atlas skips this solver (blind-bid safe).
+    function atlasSolverCall(
+        address solverOpFrom,
+        address executionEnvironment,
+        address bidToken,
+        uint256 bidAmount,
+        bytes calldata solverOpData,
+        bytes calldata /* extraReturnData */
+    ) external payable override nonReentrant {
+        // --- 1. Authorization ---------------------------------------------------------------
+        if (atlas == address(0) || executor == address(0)) revert NotConfigured();
+        if (msg.sender != atlas) revert NotAtlas();
+        if (solverOpFrom != authorizedSearcher) revert UnauthorizedSearcher();
+
+        address base = baseToken;
+
+        // --- 2. Bid token sanity ------------------------------------------------------------
+        // This solver only realizes value in the base token (the round-trip starts and ends in
+        // base). A native bid is acceptable iff base is the native-wrapper proxy the caller wired;
+        // otherwise an ERC20 bid MUST be the base token. Anything else, we cannot settle -> revert.
+        if (bidToken != base && bidToken != address(0)) revert UnsupportedBidToken();
+
+        // --- 3. Execute the backrun via the commodity executor ------------------------------
+        Backrun memory br = abi.decode(solverOpData, (Backrun));
+
+        // Defense-in-depth: force the executor's economic backstop to clear PRINCIPAL + BID, so a
+        // borderline swap that would dip into principal (or not cover the bid) reverts inside the
+        // executor rather than here. The required output is amountIn (principal) + bidAmount; we
+        // take the max of that and the searcher's own minAmountOut.
+        uint256 bidFloor = br.amountIn + bidAmount; // principal must survive AND bid must be paid
+        uint256 enforcedMin = br.minAmountOut > bidFloor ? br.minAmountOut : bidFloor;
+
+        // Approve the executor to pull exactly amountIn of base from this contract for this call.
+        // (executeSwapMultiDex does safeTransferFrom(base, msg.sender=this, executor, amountIn).)
+        // _safeApprove tolerates non-standard (no-return) base tokens, matching SwapMathLib's
+        // success+returndata convention; for standard bool-returning tokens behavior is identical.
+        _safeApprove(base, executor, br.amountIn);
+
+        uint256 grossOut = IBofhContractV2(executor).executeSwapMultiDex(
+            br.path,
+            br.fees,
+            br.dexIds,
+            br.amountIn,
+            enforcedMin,
+            br.deadline
+        );
+
+        // Clear any residual approval (executor pulls exactly amountIn, but be defensive).
+        _safeApprove(base, executor, 0);
+
+        // The executor returns `grossOut` base token to THIS contract (it pays msg.sender == us).
+        // The REALIZED PROFIT is grossOut - amountIn: the principal (amountIn) was this solver's own
+        // working float and must be preserved so it can run the next metacall. The bid + sweep are
+        // therefore paid out of PROFIT, never out of principal. If profit can't cover the bid we
+        // revert (BidNotCovered) -> Atlas skips us, blind-bid accounting holds, principal untouched.
+        if (grossOut < br.amountIn) revert BidNotCovered(grossOut, bidAmount); // (defense; executor min should already guard)
+        uint256 profit = grossOut - br.amountIn;
+        if (profit < bidAmount) revert BidNotCovered(profit, bidAmount);
+
+        // --- 4. Settle the bid + Atlas gas shortfall ---------------------------------------
+        // Pay the committed bid to the Execution Environment in the bid token. For an ERC20 base
+        // token that means transferring `bidAmount` base to the EE; the EE/Atlas accounting then
+        // reflects the won bid. For a native bid we'd unwrap+send (left as a TODO below since the
+        // mock + this play settle in the ERC20 base token).
+        if (bidToken == address(0)) {
+            // TODO(native-bid): unwrap WETH/WBNB and send `bidAmount` wei to executionEnvironment.
+            // Not exercised by this play (base-token settlement); revert keeps accounting honest.
+            revert UnsupportedBidToken();
+        }
+        if (bidAmount > 0) {
+            // Tolerant transfer (success + optional bool returndata) so a no-return base token settles.
+            SwapMathLib.safeTransfer(base, executionEnvironment, bidAmount);
+        }
+
+        // Reconcile any native gas liability Atlas reports. SolverBase does this via the escrow's
+        // shortfall()/reconcile() handshake; we forward whatever native value we were given. When
+        // there is no shortfall (or the escrow isn't a reconcile()-style Atlas), this is a no-op.
+        _reconcileAtlas();
+
+        // --- 5. Sweep the post-bid PROFIT to the beneficiary (principal stays in the solver) --
+        uint256 surplus = profit - bidAmount;
+        if (surplus > 0) {
+            SwapMathLib.safeTransfer(base, beneficiary, surplus);
+        }
+
+        emit BackrunSettled(executionEnvironment, bidToken, bidAmount, grossOut, surplus);
+    }
+
+    /// @notice Tolerant ERC20 approve mirroring {SwapMathLib.safeTransfer}'s success+returndata check.
+    /// @dev A standard token returns `true`; a non-standard (no-return) token returns zero bytes. Both
+    /// @dev are accepted; a `false` return or a failed call reverts with {IBofhContract.TransferFailed}.
+    /// @dev Behavior is identical to the previous raw approve() for standard tokens.
+    /// @param token Token to approve
+    /// @param spender Address allowed to pull
+    /// @param amount Allowance to set
+    function _safeApprove(address token, address spender, uint256 amount) private {
+        (bool success, bytes memory ret) =
+            token.call(abi.encodeWithSelector(IBEP20.approve.selector, spender, amount));
+        if (!success || (ret.length != 0 && !abi.decode(ret, (bool)))) {
+            revert IBofhContract.TransferFailed();
+        }
+    }
+
+    /// @notice Settle any native gas liability Atlas reports for this metacall.
+    /// @dev Mirrors the FastLane SolverBase `safetyFirst` tail: ask the escrow for the outstanding
+    /// @dev shortfall and reconcile up to that amount with the native value forwarded into this
+    /// @dev call. Wrapped in a low-level staticcall/try so a non-reconcile escrow (e.g. the unit
+    /// @dev test mock) does not brick settlement. Real wiring is finalized at GATE-0.
+    function _reconcileAtlas() private {
+        // Best-effort: only attempt when we actually hold native value to forward.
+        uint256 bal = address(this).balance;
+        if (bal == 0) return;
+
+        // Ask for the shortfall; tolerate escrows that don't implement it.
+        (bool okShort, bytes memory ret) =
+            atlas.staticcall(abi.encodeWithSelector(IAtlasEscrow.shortfall.selector));
+        if (!okShort || ret.length < 32) return;
+
+        uint256 owed = abi.decode(ret, (uint256));
+        if (owed == 0) return;
+
+        uint256 pay = owed < bal ? owed : bal;
+        // reconcile is payable; forward `pay`. Tolerate failure (GATE-0 finalizes the convention).
+        (bool okRec, ) = atlas.call{value: pay}(
+            abi.encodeWithSelector(IAtlasEscrow.reconcile.selector, pay)
+        );
+        okRec; // intentionally ignored: settlement correctness is re-asserted by Atlas post-call
+    }
+
+    /// @notice Owner escape hatch: recover tokens accidentally parked here (this contract is
+    /// @notice non-custodial by design, but a misrouted transfer should never be trapped).
+    /// @param token The ERC20 to sweep
+    /// @param to Recipient
+    /// @param amount Amount to sweep
+    function rescueToken(address token, address to, uint256 amount) external onlyOwner {
+        if (to == address(0)) revert ZeroAddress();
+        // Tolerant transfer so even a misrouted non-standard (no-return) token can be recovered.
+        SwapMathLib.safeTransfer(token, to, amount);
+    }
+
+    /// @notice Accept native value (Atlas may forward gas value through atlasSolverCall).
+    receive() external payable {}
+}

--- a/contracts/solvers/IAtlasSolver.sol
+++ b/contracts/solvers/IAtlasSolver.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.10;
+
+/// @title IAtlasSolver - Atlas / FastLane solver-contract integration surface
+/// @author Bofh Team
+/// @notice Solidity transcription of the Atlas v1.x solver entrypoint and the SolverOperation
+/// @notice handoff, as fetched from the FastLane-Labs/atlas repository and the FastLane
+/// @notice searcher-contract-integration docs (Jan 2026 snapshot). A solver contract that wants
+/// @notice to win a backrun in an Atlas auction MUST implement {ISolverContract.atlasSolverCall}.
+/// @dev SOURCES (verbatim signatures transcribed, NOT invented):
+/// @dev   - src/contracts/interfaces/ISolverContract.sol  (atlasSolverCall)
+/// @dev   - src/contracts/types/SolverOperation.sol        (struct SolverOperation)
+/// @dev   - src/contracts/solver/SolverBase.sol            (reference safetyFirst/payBids flow)
+/// @dev   - fastlane-labs.gitbook.io/.../searcher-contract-integration
+/// @dev
+/// @dev ====================================================================================
+/// @dev GATE-0 (READ BEFORE ANY DEPLOY/BOND): On 22 Jan 2026 Chainlink ACQUIRED Atlas and
+/// @dev pivoted toward SVR-liquidation flow. The continued OPENNESS of the permissionless
+/// @dev DEX-backrun OFA (i.e. that an outside searcher can still register a SolverOperation and
+/// @dev win a backrun without a Chainlink-gated allowlist) MUST be verified LIVE before this
+/// @dev interface is wired to a real Atlas deployment. Treat the pin below as advisory until
+/// @dev re-confirmed against the live Atlas address on the target chain.
+/// @dev ====================================================================================
+
+/// @notice The SolverOperation passed through the Atlas pipeline (verbatim field order/types
+/// @notice from src/contracts/types/SolverOperation.sol). It is signed by `from` (the searcher
+/// @notice EOA) and routed by the Atlas bundler/auctioneer. The solver contract sees the bid
+/// @notice parameters as decomposed arguments in {atlasSolverCall}; this struct is included so the
+/// @notice off-chain bundler-side encoding and any on-chain helpers reference one definition.
+/// @custom:field from EOA that signed this SolverOperation (the searcher)
+/// @custom:field to The Atlas contract address (the SolverOperation target)
+/// @custom:field value Native value the solver op is allowed to spend
+/// @custom:field gas Gas the solver op is metered to
+/// @custom:field maxFeePerGas Max fee-per-gas the searcher will pay
+/// @custom:field deadline Block number after which the op is invalid
+/// @custom:field solver The solver CONTRACT address Atlas will call atlasSolverCall on
+/// @custom:field control The DAppControl address governing this auction
+/// @custom:field userOpHash Hash binding this solver op to the user op it backruns
+/// @custom:field bidToken Token the bid is denominated in (address(0) == native)
+/// @custom:field bidAmount Amount of bidToken the solver commits to pay if it wins
+/// @custom:field data Calldata forwarded to the solver (decoded by the solver itself)
+/// @custom:field signature EIP-712 signature of `from` over the op
+struct SolverOperation {
+    address from;
+    address to;
+    uint256 value;
+    uint256 gas;
+    uint256 maxFeePerGas;
+    uint256 deadline;
+    address solver;
+    address control;
+    bytes32 userOpHash;
+    address bidToken;
+    uint256 bidAmount;
+    bytes data;
+    bytes signature;
+}
+
+/// @title ISolverContract - the single function Atlas invokes on a solver contract
+/// @notice Atlas calls this on the contract named by {SolverOperation.solver}. The solver must:
+/// @notice  (1) verify msg.sender is the Atlas contract (and, if it cares, that solverOpFrom is
+/// @notice      an authorized searcher) — Atlas guarantees ordering but NOT that the solver only
+/// @notice      runs for its owner;
+/// @notice  (2) execute its MEV strategy using `solverOpData`;
+/// @notice  (3) leave `bidAmount` of `bidToken` available so the Atlas escrow accounting nets
+/// @notice      out (the SolverBase reference impl repays via reconcile() + a transfer of the
+/// @notice      bid to the executionEnvironment); and
+/// @notice  (4) revert on any failure so Atlas's ex-post BLIND accounting skips this solver and
+/// @notice      tries the next-best bid (a clean revert is the correct "I can't pay" signal).
+/// @dev atlasSolverCall is `payable` because native-denominated bids/values flow through it.
+interface ISolverContract {
+    /// @notice Entry point Atlas invokes for this solver during the solver phase of a metacall.
+    /// @param solverOpFrom The EOA that signed the winning SolverOperation (the searcher)
+    /// @param executionEnvironment The per-(user,dApp) Execution Environment Atlas is running in;
+    /// @param executionEnvironment this is the address the bid must ultimately be payable to
+    /// @param bidToken The token the bid is denominated in (address(0) == native asset)
+    /// @param bidAmount The amount of bidToken this solver committed to pay if it wins
+    /// @param solverOpData The opaque solver calldata (SolverOperation.data) to decode+execute
+    /// @param extraReturnData Any data returned by earlier phases (e.g. the userOp/preOps return)
+    function atlasSolverCall(
+        address solverOpFrom,
+        address executionEnvironment,
+        address bidToken,
+        uint256 bidAmount,
+        bytes calldata solverOpData,
+        bytes calldata extraReturnData
+    ) external payable;
+}
+
+/// @title IAtlasEscrow - the slice of the Atlas contract a SolverBase-style solver touches
+/// @notice Minimal view of the Atlas escrow used by the reference SolverBase safety modifier to
+/// @notice settle borrowed gas/value (reconcile against the reported shortfall). Surfaced here so
+/// @notice {BofhAtlasSolver} and {MockAtlas} share ONE definition of the repayment handshake.
+/// @dev Real Atlas exposes more; this is intentionally narrow to what the solver leg requires.
+interface IAtlasEscrow {
+    /// @notice The native/gas liability Atlas expects the solver to cover for this metacall.
+    /// @return The outstanding borrow liability (in wei) the solver must reconcile.
+    function shortfall() external view returns (uint256);
+
+    /// @notice Repay (some or all of) the outstanding shortfall to the Atlas escrow.
+    /// @param maxApprovedGasSpend Amount of native value the solver forwards to settle the debt
+    /// @return owed The remaining amount still owed after this reconcile (0 == fully settled)
+    function reconcile(uint256 maxApprovedGasSpend) external payable returns (uint256 owed);
+}

--- a/test/AtlasSolver.test.js
+++ b/test/AtlasSolver.test.js
@@ -1,0 +1,712 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Atlas/FastLane backrun SOLVER contract tests (Play #1).
+ *
+ * BofhAtlasSolver is the Atlas solver leg: Atlas (here MockAtlas) calls atlasSolverCall with a
+ * winning bid; the solver decodes a multi-DEX backrun, settles it through the already-audited
+ * BofhContractV2.executeSwapMultiDex commodity executor, pays the committed bid to the Execution
+ * Environment, and sweeps the surplus to the beneficiary.
+ *
+ * The executor is NON-CUSTODIAL: it pulls amountIn of base from the solver (via approve) for the
+ * duration of the call and returns the round-trip output to the solver. The solver therefore holds
+ * working capital only for the metacall's "borrow" leg — we seed it with base at fixture time to
+ * model that float.
+ *
+ * GATE-0 (mirrored from the contract NatSpec): these tests prove the WIRING + accounting only. They
+ * do NOT establish that a permissionless Atlas DEX-backrun OFA is still open post-Chainlink, nor
+ * that the edge clears net-of-gas on real data. Both are external prerequisites to any deploy/bond.
+ */
+describe("BofhAtlasSolver (Atlas backrun solver leg)", function () {
+  const MAX_UINT256 = ethers.MaxUint256;
+
+  // Constant-product amount-out, identical to executePathStep's on-chain formula.
+  function getAmountOut(amountIn, reserveIn, reserveOut, feeBps) {
+    const feeNum = 10000n - BigInt(feeBps);
+    const amountInWithFee = amountIn * feeNum;
+    const numerator = amountInWithFee * reserveOut;
+    const denominator = reserveIn * 10000n + amountInWithFee;
+    return numerator / denominator;
+  }
+
+  async function deadlineFromNow() {
+    return (await ethers.provider.getBlock("latest")).timestamp + 3600;
+  }
+
+  /**
+   * Profitable-backrun fixture.
+   *
+   * Two DEXes for the BASE/A pair. We DELIBERATELY imbalance pool1 so that a BASE->A->BASE
+   * round-trip (hop0 on dexId0, hop1 on dexId1) nets MORE base than it spent — that surplus is the
+   * arbitrage the backrun captures, out of which the bid is paid.
+   *
+   *   pool0 (dexId 0): BASE=1,000,000  A=1,000,000   (fair)
+   *   pool1 (dexId 1): BASE=2,000,000  A=1,000,000   (A is "expensive" / BASE is cheap here, so
+   *                                                   selling A into pool1 returns lots of BASE)
+   *
+   * Fees set to 0 on both pools (and fees=[0,0]) so the expected output is exactly computable and
+   * the imbalance alone drives the profit.
+   */
+  async function deployProfitableFixture() {
+    const [owner, searcher, stranger, beneficiary] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+
+    const MockFactory = await ethers.getContractFactory("MockFactory");
+    const factory0 = await MockFactory.deploy();
+    const factory1 = await MockFactory.deploy();
+
+    const baseAddr = await baseToken.getAddress();
+    const aAddr = await tokenA.getAddress();
+
+    await factory0.createPair(baseAddr, aAddr);
+    await factory1.createPair(baseAddr, aAddr);
+
+    const pair0Addr = await factory0.getPair(baseAddr, aAddr);
+    const pair1Addr = await factory1.getPair(baseAddr, aAddr);
+
+    const MockPair = await ethers.getContractFactory("MockPair");
+    const pair0 = MockPair.attach(pair0Addr);
+    const pair1 = MockPair.attach(pair1Addr);
+
+    // pool0: fair 1:1
+    const baseReserve0 = ethers.parseEther("1000000");
+    const aReserve0 = ethers.parseEther("1000000");
+    await baseToken.transfer(pair0Addr, baseReserve0);
+    await tokenA.transfer(pair0Addr, aReserve0);
+    await pair0.sync();
+
+    // pool1: BASE-heavy so A->BASE returns extra BASE => round-trip profit
+    const baseReserve1 = ethers.parseEther("2000000");
+    const aReserve1 = ethers.parseEther("1000000");
+    await baseToken.transfer(pair1Addr, baseReserve1);
+    await tokenA.transfer(pair1Addr, aReserve1);
+    await pair1.sync();
+
+    await pair0.setSwapFee(0);
+    await pair1.setSwapFee(0);
+
+    const BofhContractV2 = await ethers.getContractFactory("BofhContractV2");
+    const executor = await BofhContractV2.deploy(baseAddr, await factory0.getAddress());
+    await executor.connect(owner).setDex(1, await factory1.getAddress(), 0, true);
+
+    const BofhAtlasSolver = await ethers.getContractFactory("BofhAtlasSolver");
+    const solver = await BofhAtlasSolver.connect(owner).deploy();
+    await solver.connect(owner).configureExecutor(await executor.getAddress(), baseAddr);
+
+    const MockAtlas = await ethers.getContractFactory("MockAtlas");
+    const atlas = await MockAtlas.deploy();
+    await solver
+      .connect(owner)
+      .configureAtlas(await atlas.getAddress(), searcher.address);
+    await solver.connect(owner).setBeneficiary(beneficiary.address);
+
+    // Seed the solver with base-token float for the borrow leg (executor pulls amountIn from it).
+    const float = ethers.parseEther("100000");
+    await baseToken.transfer(await solver.getAddress(), float);
+
+    // Helper: exact round-trip output for a given amountIn through pool0 (0 fee) then pool1 (0 fee).
+    function roundTripOut(amountIn) {
+      const out1 = getAmountOut(amountIn, baseReserve0, aReserve0, 0); // BASE->A on pool0
+      const out2 = getAmountOut(out1, aReserve1, baseReserve1, 0); // A->BASE on pool1
+      return out2;
+    }
+
+    return {
+      owner, searcher, stranger, beneficiary,
+      baseToken, tokenA, baseAddr, aAddr,
+      factory0, factory1,
+      executor, solver, atlas,
+      float, roundTripOut,
+    };
+  }
+
+  function encodeBackrun(br) {
+    const coder = ethers.AbiCoder.defaultAbiCoder();
+    return coder.encode(
+      [
+        "tuple(address[] path,uint256[] fees,uint16[] dexIds,uint256 amountIn,uint256 minAmountOut,uint256 deadline)",
+      ],
+      [br]
+    );
+  }
+
+  /**
+   * Mock-executor fixture used to ISOLATE the solver's OWN profit guard.
+   *
+   * In the real path the solver forces enforcedMin = max(minAmountOut, amountIn + bidAmount), so
+   * BofhContractV2 reverts InsufficientOutput before the solver's `grossOut < amountIn` /
+   * `profit < bidAmount` checks can ever run. To exercise those two branches directly we point the
+   * solver at MockSolverExecutor, which IGNORES minAmountOut and returns a caller-chosen grossOut
+   * (after pulling amountIn exactly like the real, non-custodial executor). The mock is seeded with
+   * extra base so it can also return grossOut > amountIn for the profit<bid branch.
+   */
+  async function deployMockExecutorFixture() {
+    const [owner, searcher, stranger, beneficiary] = await ethers.getSigners();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    const baseToken = await MockToken.deploy("Base Token", "BASE", ethers.parseEther("100000000"));
+    const tokenA = await MockToken.deploy("Token A", "TKNA", ethers.parseEther("100000000"));
+    const baseAddr = await baseToken.getAddress();
+    const aAddr = await tokenA.getAddress();
+
+    const MockSolverExecutor = await ethers.getContractFactory("MockSolverExecutor");
+    const mockExec = await MockSolverExecutor.deploy(baseAddr);
+
+    const BofhAtlasSolver = await ethers.getContractFactory("BofhAtlasSolver");
+    const solver = await BofhAtlasSolver.connect(owner).deploy();
+    await solver.connect(owner).configureExecutor(await mockExec.getAddress(), baseAddr);
+
+    const MockAtlas = await ethers.getContractFactory("MockAtlas");
+    const atlas = await MockAtlas.deploy();
+    await solver.connect(owner).configureAtlas(await atlas.getAddress(), searcher.address);
+    await solver.connect(owner).setBeneficiary(beneficiary.address);
+
+    // Solver float (principal it lends to the executor for the borrow leg).
+    const float = ethers.parseEther("100000");
+    await baseToken.transfer(await solver.getAddress(), float);
+    // Mock executor liquidity so it can hand back grossOut (possibly > amountIn).
+    await baseToken.transfer(await mockExec.getAddress(), ethers.parseEther("100000"));
+
+    return {
+      owner, searcher, stranger, beneficiary,
+      baseToken, tokenA, baseAddr, aAddr,
+      mockExec, solver, atlas, float,
+    };
+  }
+
+  describe("Configuration & access control", function () {
+    it("constructor sets owner and beneficiary to deployer", async function () {
+      const { solver, owner } = await loadFixture(deployProfitableFixture);
+      // beneficiary was reassigned in fixture; owner remains the deployer.
+      expect(await solver.owner()).to.equal(owner.address);
+    });
+
+    it("non-owner cannot configureExecutor / configureAtlas / setBeneficiary", async function () {
+      const { solver, stranger, executor, baseAddr, atlas } =
+        await loadFixture(deployProfitableFixture);
+      await expect(
+        solver.connect(stranger).configureExecutor(await executor.getAddress(), baseAddr)
+      ).to.be.revertedWithCustomError(solver, "NotOwner");
+      await expect(
+        solver.connect(stranger).configureAtlas(await atlas.getAddress(), stranger.address)
+      ).to.be.revertedWithCustomError(solver, "NotOwner");
+      await expect(
+        solver.connect(stranger).setBeneficiary(stranger.address)
+      ).to.be.revertedWithCustomError(solver, "NotOwner");
+    });
+
+    it("rejects zero-address configuration", async function () {
+      const { solver, owner, baseAddr } = await loadFixture(deployProfitableFixture);
+      await expect(
+        solver.connect(owner).configureExecutor(ethers.ZeroAddress, baseAddr)
+      ).to.be.revertedWithCustomError(solver, "ZeroAddress");
+      await expect(
+        solver.connect(owner).configureAtlas(ethers.ZeroAddress, owner.address)
+      ).to.be.revertedWithCustomError(solver, "ZeroAddress");
+    });
+
+    it("atlasSolverCall reverts if caller is not the configured Atlas (NotAtlas)", async function () {
+      const { solver, stranger, searcher, baseAddr } =
+        await loadFixture(deployProfitableFixture);
+      // A direct (non-Atlas) caller must be rejected before any work happens.
+      const br = encodeBackrun({
+        path: [baseAddr, baseAddr],
+        fees: [0],
+        dexIds: [0],
+        amountIn: 1n,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+      await expect(
+        solver
+          .connect(stranger)
+          .atlasSolverCall(searcher.address, stranger.address, baseAddr, 0, br, "0x")
+      ).to.be.revertedWithCustomError(solver, "NotAtlas");
+    });
+  });
+
+  describe("Backrun settlement (happy path)", function () {
+    it("routes a profitable backrun through the executor, repays the bid, sweeps surplus", async function () {
+      const {
+        solver, atlas, searcher, beneficiary,
+        baseToken, baseAddr, aAddr, roundTripOut, float,
+      } = await loadFixture(deployProfitableFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const grossOut = roundTripOut(amountIn);
+      expect(grossOut).to.be.greaterThan(amountIn); // sanity: this backrun IS profitable
+
+      // Bid a portion of the realized profit (must be <= grossOut, and we leave headroom).
+      const profit = grossOut - amountIn;
+      const bidAmount = profit / 2n;
+
+      const br = {
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      };
+      const data = encodeBackrun(br);
+
+      const eeAddr = await atlas.getAddress(); // EE == the mock atlas in default config
+      const eeBefore = await baseToken.balanceOf(eeAddr);
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      const solverBefore = await baseToken.balanceOf(await solver.getAddress());
+
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, data)
+      ).to.emit(solver, "BackrunSettled");
+
+      const eeAfter = await baseToken.balanceOf(eeAddr);
+      const benAfter = await baseToken.balanceOf(beneficiary.address);
+      const solverAfter = await baseToken.balanceOf(await solver.getAddress());
+
+      // Bid paid to EE exactly.
+      expect(eeAfter - eeBefore).to.equal(bidAmount);
+      // Surplus = PROFIT - bidAmount swept to beneficiary (principal stays in the solver).
+      expect(benAfter - benBefore).to.equal(profit - bidAmount);
+      // Non-custodial principal preservation: the solver's base float is exactly conserved across
+      // the metacall. It lent amountIn (pulled by executor) and got grossOut back; out of the
+      // grossOut - amountIn profit it paid bid(EE) + surplus(beneficiary) = profit, leaving the
+      // original amountIn principal -> float unchanged.
+      expect(solverAfter).to.equal(solverBefore);
+      expect(solverAfter).to.equal(float);
+    });
+
+    it("zero bid still settles and sweeps the full PROFIT (not principal) to the beneficiary", async function () {
+      const {
+        solver, atlas, searcher, beneficiary,
+        baseToken, baseAddr, aAddr, roundTripOut,
+      } = await loadFixture(deployProfitableFixture);
+
+      const amountIn = ethers.parseEther("500");
+      const grossOut = roundTripOut(amountIn);
+      const profit = grossOut - amountIn;
+
+      const br = {
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      };
+
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      const solverBefore = await baseToken.balanceOf(await solver.getAddress());
+      await atlas.metacall(
+        await solver.getAddress(),
+        searcher.address,
+        baseAddr,
+        0,
+        encodeBackrun(br)
+      );
+      const benAfter = await baseToken.balanceOf(beneficiary.address);
+      // With a zero bid the whole profit is swept; principal stays in the solver.
+      expect(benAfter - benBefore).to.equal(profit);
+      expect(await baseToken.balanceOf(await solver.getAddress())).to.equal(solverBefore);
+    });
+  });
+
+  describe("Reverts that keep Atlas blind-bid accounting honest", function () {
+    it("reverts UnauthorizedSearcher when solverOpFrom is not the registered searcher", async function () {
+      const { solver, atlas, stranger, baseAddr, aAddr } =
+        await loadFixture(deployProfitableFixture);
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn: ethers.parseEther("100"),
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+      await expect(
+        atlas.metacall(await solver.getAddress(), stranger.address, baseAddr, 0, br)
+      ).to.be.revertedWithCustomError(solver, "UnauthorizedSearcher");
+    });
+
+    it("reverts when the bid exceeds the realized output (under-profit) — nothing settles", async function () {
+      const {
+        solver, atlas, searcher, beneficiary,
+        baseToken, baseAddr, aAddr, roundTripOut,
+      } = await loadFixture(deployProfitableFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const grossOut = roundTripOut(amountIn);
+      const tooBigBid = grossOut + 1n; // cannot possibly be covered
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      // enforcedMin = max(minAmountOut, bid) = tooBigBid > grossOut => the EXECUTOR rejects first
+      // with InsufficientOutput; either way the metacall reverts and nothing is paid.
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, tooBigBid, br)
+      ).to.be.reverted;
+      const benAfter = await baseToken.balanceOf(beneficiary.address);
+      expect(benAfter).to.equal(benBefore); // blind-bid: no partial settlement
+    });
+
+    it("reverts (executor InsufficientOutput) when the backrun is unprofitable vs minAmountOut", async function () {
+      const { solver, atlas, executor, searcher, baseToken, beneficiary, baseAddr, aAddr, roundTripOut } =
+        await loadFixture(deployProfitableFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const grossOut = roundTripOut(amountIn);
+
+      // Demand more out than the pools can deliver, with a zero bid (so the failure is the
+      // searcher's own minAmountOut, exercised inside the executor). InsufficientOutput is an
+      // ERROR on the EXECUTOR contract, so the matcher is asserted against `executor`.
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: grossOut + ethers.parseEther("1"),
+        deadline: await deadlineFromNow(),
+      });
+
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, 0, br)
+      ).to.be.revertedWithCustomError(executor, "InsufficientOutput");
+      expect(await baseToken.balanceOf(beneficiary.address)).to.equal(benBefore);
+    });
+
+    it("reverts BidNotCovered when profit is positive but smaller than the committed bid", async function () {
+      // Here the round-trip IS profitable (clears principal) but the bid exceeds the profit, so the
+      // solver-level profit check (not the executor) is the gate. We craft a bid strictly between
+      // profit and grossOut, and force the executor min to NOT pre-empt it by sending a low
+      // minAmountOut — but enforcedMin = amountIn + bid would still trip the executor first. To
+      // isolate the solver's BidNotCovered branch we instead rely on the executor returning exactly
+      // grossOut and the solver computing profit < bid. Because enforcedMin = amountIn + bid and
+      // grossOut < amountIn + bid here, the EXECUTOR reverts InsufficientOutput first; either way
+      // nothing settles. We assert the metacall reverts and the beneficiary is untouched.
+      const { solver, atlas, searcher, baseToken, beneficiary, baseAddr, aAddr, roundTripOut } =
+        await loadFixture(deployProfitableFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const grossOut = roundTripOut(amountIn);
+      const profit = grossOut - amountIn;
+      const overBid = profit + 1n; // covered by gross output, NOT by profit
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, overBid, br)
+      ).to.be.reverted; // executor min (amountIn+bid) or solver BidNotCovered — no settlement either way
+      expect(await baseToken.balanceOf(beneficiary.address)).to.equal(benBefore);
+    });
+
+    it("reverts UnsupportedBidToken for a non-base ERC20 bid token", async function () {
+      const { solver, atlas, searcher, aAddr, baseAddr } =
+        await loadFixture(deployProfitableFixture);
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn: ethers.parseEther("100"),
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+      // bidToken = tokenA (not the base token) => unsettleable here.
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, aAddr, 0, br)
+      ).to.be.revertedWithCustomError(solver, "UnsupportedBidToken");
+    });
+
+    it("reverts NotConfigured when Atlas/executor not yet wired", async function () {
+      const { owner, searcher, baseAddr, aAddr } = await loadFixture(deployProfitableFixture);
+      // Fresh, unconfigured solver.
+      const BofhAtlasSolver = await ethers.getContractFactory("BofhAtlasSolver");
+      const bare = await BofhAtlasSolver.connect(owner).deploy();
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn: 1n,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+      // Called directly (owner stands in as caller) — NotConfigured fires before NotAtlas because
+      // atlas==0 and executor==0.
+      await expect(
+        bare
+          .connect(owner)
+          .atlasSolverCall(searcher.address, owner.address, baseAddr, 0, br, "0x")
+      ).to.be.revertedWithCustomError(bare, "NotConfigured");
+    });
+  });
+
+  describe("Atlas gas-shortfall reconcile handshake", function () {
+    it("reconciles a reported native shortfall when the solver holds native value", async function () {
+      const {
+        solver, atlas, searcher, owner, baseToken, baseAddr, aAddr, roundTripOut,
+      } = await loadFixture(deployProfitableFixture);
+
+      // Atlas reports a small native gas debt; fund the solver with native value to settle it.
+      const shortfall = ethers.parseEther("0.01");
+      await atlas.setShortfall(shortfall);
+      await owner.sendTransaction({ to: await solver.getAddress(), value: shortfall });
+
+      const amountIn = ethers.parseEther("1000");
+      const grossOut = roundTripOut(amountIn);
+      const bidAmount = (grossOut - amountIn) / 2n;
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      await atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br);
+
+      // The solver forwarded its native balance to reconcile the reported shortfall.
+      expect(await atlas.lastReconciled()).to.equal(shortfall);
+      expect(await atlas.reportedShortfall()).to.equal(0n);
+    });
+  });
+
+  // --------------------------------------------------------------------------------------------
+  // Solver-level BidNotCovered guard (review fix #1)
+  //
+  // These hit the solver's OWN profit checks at BofhAtlasSolver ~L279/L281, which the real
+  // executor's enforcedMin backstop pre-empts. The MockSolverExecutor returns a chosen grossOut so
+  // both branches are reachable and we can prove NOTHING settles when they fire (blind-bid safe).
+  // --------------------------------------------------------------------------------------------
+  describe("Solver-level BidNotCovered guard (isolated via mock executor)", function () {
+    it("(a) reverts BidNotCovered when grossOut < amountIn (executor under-delivers principal)", async function () {
+      const { solver, atlas, searcher, beneficiary, baseToken, baseAddr, aAddr, mockExec, float } =
+        await loadFixture(deployMockExecutorFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      // Executor hands back LESS than principal -> grossOut < amountIn -> first guard trips.
+      const grossOut = amountIn - ethers.parseEther("1");
+      await mockExec.setNextGrossOut(grossOut);
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const eeAddr = await atlas.getAddress();
+      const eeBefore = await baseToken.balanceOf(eeAddr);
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      const solverBefore = await baseToken.balanceOf(await solver.getAddress());
+
+      // Zero bid: isolates the grossOut<amountIn branch specifically (bidAmount=0 can't trip L281).
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, 0, br)
+      ).to.be.revertedWithCustomError(solver, "BidNotCovered").withArgs(grossOut, 0n);
+
+      // No partial settlement: EE + beneficiary untouched, solver float fully restored by the revert.
+      expect(await baseToken.balanceOf(eeAddr)).to.equal(eeBefore);
+      expect(await baseToken.balanceOf(beneficiary.address)).to.equal(benBefore);
+      expect(await baseToken.balanceOf(await solver.getAddress())).to.equal(solverBefore);
+      expect(await baseToken.balanceOf(await solver.getAddress())).to.equal(float);
+    });
+
+    it("(b) reverts BidNotCovered when grossOut > amountIn but profit < bidAmount", async function () {
+      const { solver, atlas, searcher, beneficiary, baseToken, baseAddr, aAddr, mockExec, float } =
+        await loadFixture(deployMockExecutorFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      // Profitable vs principal (grossOut > amountIn) but the profit is SMALLER than the bid.
+      const profit = ethers.parseEther("10");
+      const grossOut = amountIn + profit;        // > amountIn -> first guard passes
+      const bidAmount = profit + ethers.parseEther("1"); // bid exceeds profit -> second guard trips
+      await mockExec.setNextGrossOut(grossOut);
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const eeAddr = await atlas.getAddress();
+      const eeBefore = await baseToken.balanceOf(eeAddr);
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      const solverBefore = await baseToken.balanceOf(await solver.getAddress());
+
+      // The solver-level profit check fires with (profit, bidAmount) — NOT the executor.
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br)
+      ).to.be.revertedWithCustomError(solver, "BidNotCovered").withArgs(profit, bidAmount);
+
+      // No partial settlement: the bid was NEVER paid to the EE, surplus NEVER swept, float intact.
+      expect(await baseToken.balanceOf(eeAddr)).to.equal(eeBefore);
+      expect(await baseToken.balanceOf(beneficiary.address)).to.equal(benBefore);
+      expect(await baseToken.balanceOf(await solver.getAddress())).to.equal(solverBefore);
+      expect(await baseToken.balanceOf(await solver.getAddress())).to.equal(float);
+    });
+
+    it("settles normally when profit == bidAmount (boundary: guard does NOT trip)", async function () {
+      // Sanity boundary so the (b) guard isn't off-by-one: profit exactly equal to the bid passes.
+      const { solver, atlas, searcher, beneficiary, baseToken, baseAddr, aAddr, mockExec } =
+        await loadFixture(deployMockExecutorFixture);
+
+      const amountIn = ethers.parseEther("1000");
+      const profit = ethers.parseEther("10");
+      const grossOut = amountIn + profit;
+      const bidAmount = profit; // profit == bid -> surplus 0, must still settle (not revert)
+      await mockExec.setNextGrossOut(grossOut);
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const eeAddr = await atlas.getAddress();
+      const eeBefore = await baseToken.balanceOf(eeAddr);
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br)
+      ).to.emit(solver, "BackrunSettled");
+
+      expect((await baseToken.balanceOf(eeAddr)) - eeBefore).to.equal(bidAmount);
+      // Zero surplus swept (profit fully consumed by the bid).
+      expect(await baseToken.balanceOf(beneficiary.address)).to.equal(benBefore);
+    });
+  });
+
+  // --------------------------------------------------------------------------------------------
+  // Tolerant safe-transfer / safe-approve for non-standard (no-return) base tokens (review fix #3)
+  // --------------------------------------------------------------------------------------------
+  describe("Non-standard (no-return) base token settlement", function () {
+    it("settles a backrun whose base token's transfer/approve return NO bool", async function () {
+      const { owner, searcher, beneficiary } = await loadFixture(deployMockExecutorFixture);
+
+      // USDT/BSC-USD-style base token: transfer/transferFrom return nothing; approve returns bool.
+      const MockNoReturnToken = await ethers.getContractFactory("MockNoReturnToken");
+      const base = await MockNoReturnToken.deploy("No Return Base", "NRB", ethers.parseEther("100000000"));
+      const baseAddr = await base.getAddress();
+
+      const MockSolverExecutor = await ethers.getContractFactory("MockSolverExecutor");
+      const mockExec = await MockSolverExecutor.deploy(baseAddr);
+
+      const BofhAtlasSolver = await ethers.getContractFactory("BofhAtlasSolver");
+      const solver = await BofhAtlasSolver.connect(owner).deploy();
+      await solver.connect(owner).configureExecutor(await mockExec.getAddress(), baseAddr);
+
+      const MockAtlas = await ethers.getContractFactory("MockAtlas");
+      const atlas = await MockAtlas.deploy();
+      await solver.connect(owner).configureAtlas(await atlas.getAddress(), searcher.address);
+      await solver.connect(owner).setBeneficiary(beneficiary.address);
+
+      // Fund solver float and executor liquidity in the no-return token.
+      await base.transfer(await solver.getAddress(), ethers.parseEther("100000"));
+      await base.transfer(await mockExec.getAddress(), ethers.parseEther("100000"));
+
+      const amountIn = ethers.parseEther("1000");
+      const profit = ethers.parseEther("20");
+      const grossOut = amountIn + profit;
+      const bidAmount = profit / 2n;
+      await mockExec.setNextGrossOut(grossOut);
+
+      const br = encodeBackrun({
+        path: [baseAddr, baseAddr],
+        fees: [0],
+        dexIds: [0],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      const eeAddr = await atlas.getAddress();
+      const eeBefore = await base.balanceOf(eeAddr);
+      const benBefore = await base.balanceOf(beneficiary.address);
+
+      // If the solver still used require(token.transfer(...)) this would revert on the no-return
+      // token; the tolerant SwapMathLib.safeTransfer + _safeApprove make it settle cleanly.
+      await expect(
+        atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br)
+      ).to.emit(solver, "BackrunSettled");
+
+      expect((await base.balanceOf(eeAddr)) - eeBefore).to.equal(bidAmount);
+      expect((await base.balanceOf(beneficiary.address)) - benBefore).to.equal(profit - bidAmount);
+    });
+  });
+
+  // --------------------------------------------------------------------------------------------
+  // Reentrancy guard on atlasSolverCall (review fix #2)
+  // --------------------------------------------------------------------------------------------
+  describe("atlasSolverCall reentrancy guard", function () {
+    it("exposes a Reentrancy error and a happy-path call still settles (lock clears)", async function () {
+      // The guard is defense-in-depth; the executor it calls is already nonReentrant, so there is no
+      // in-suite re-entry vector to trip it. We assert the error selector exists and that a normal
+      // settlement succeeds (proving the lock is cleared after the call, not left stuck).
+      const { solver, atlas, searcher, beneficiary, baseToken, baseAddr, aAddr, mockExec } =
+        await loadFixture(deployMockExecutorFixture);
+
+      expect(solver.interface.getError("Reentrancy")).to.not.equal(null);
+
+      const amountIn = ethers.parseEther("1000");
+      const profit = ethers.parseEther("10");
+      await mockExec.setNextGrossOut(amountIn + profit);
+      const bidAmount = profit / 2n;
+
+      const br = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+
+      // Two back-to-back metacalls both succeed -> the lock is released between calls.
+      const benBefore = await baseToken.balanceOf(beneficiary.address);
+      await atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br);
+      await mockExec.setNextGrossOut(amountIn + profit);
+      const br2 = encodeBackrun({
+        path: [baseAddr, aAddr, baseAddr],
+        fees: [0, 0],
+        dexIds: [0, 1],
+        amountIn,
+        minAmountOut: 1n,
+        deadline: await deadlineFromNow(),
+      });
+      await atlas.metacall(await solver.getAddress(), searcher.address, baseAddr, bidAmount, br2);
+      expect((await baseToken.balanceOf(beneficiary.address)) - benBefore).to.equal(
+        2n * (profit - bidAmount)
+      );
+    });
+  });
+});


### PR DESCRIPTION
The deep-research report's **#1 play**: the executor is a commodity settlement leg whose best fit is plugging into a **sealed-bid on-chain backrun auction** (Atlas/FastLane on a cheap L2) — no latency race, L2 gas makes the executor's relative gas-fatness cost cents, and backruns are atomic/flash-loan-eligible.

## What's here
- **`contracts/solvers/IAtlasSolver.sol`** — the **real** Atlas `ISolverContract` / `SolverOperation` / escrow interface, transcribed from the `FastLane-Labs/atlas` source (not invented).
- **`contracts/solvers/BofhAtlasSolver.sol`** — on `atlasSolverCall`: gates `msg.sender == atlas` + an authorized searcher, decodes a `Backrun(path, fees, dexIds, amountIn, minAmountOut, deadline)`, runs it through the deployed `BofhContractV2.executeSwapMultiDex`, **repays the bid**, **sweeps profit** to the beneficiary, and **preserves principal** (non-custodial). Reverts cleanly on unprofitable / under-min / unauthorized so Atlas's ex-post blind-bid accounting holds. `nonReentrant`; `SwapMathLib.safeTransfer` + a no-return-token-tolerant `_safeApprove`; `onlyOwner` config + `rescueToken`.
- **`contracts/mocks/{MockAtlas,MockSolverExecutor}.sol`** + **`test/AtlasSolver.test.js`** (18 tests): profitable backrun repays bid + sweeps profit + preserves principal; `BidNotCovered` both branches; access control; reconcile/shortfall handshake; no-return token.

## ⚠️ GATE-0 (in NatSpec — do NOT skip)
**Do not deploy / bond / pay for an audit** until:
1. The permissionless Atlas **DEX-backrun OFA is verified still open** on the target chain **post the 22-Jan-2026 Chainlink acquisition** (which pivoted Atlas toward SVR-liquidation flow — openness must be re-confirmed live), AND
2. the **edge is proven net-of-gas GO** on real data via `research/backtester.js`.

Native-bid (`bidToken == address(0)`) settlement and the exact live `reconcile`/shortfall convention are documented in-contract **TODOs** to finalize against the pinned Atlas release at Gate-0.

## Verification
- `hardhat compile` (london) ✅ · full suite **344 passing** (326 + 18 new), 4 pending, **0 failing** ✅

> Companion off-chain PR (`feat/2026-offchain-tooling`) adds the long-tail/fresh-pool research toolkit (#3), the token-safety guard (#4), and the CoW solver-filler scaffold (#2). The backtester there is the GATE-0 evidence gate for this contract.