### PR TITLE
feat(research+cow): long-tail toolkit, token-safety guard, CoW solver scaffold (2026 plays #2-#4)

### DIFF
--- a/research/README.md
+++ b/research/README.md
@@ -38,6 +38,14 @@ The whole pipeline is a gate, not a product. We never assume an edge; we make a 
 earn. The decision lives in `backtester.js::applyKillCriteria` and the thresholds in
 `config.*.json → kill`:
 
+Before any candidate is even scored, the **token-safety GATE** (PLAY #4, `tokenSafety.js`)
+runs a **per-token base<->token buy-then-sell probe** (one independent 2-hop `base->token->base`
+round-trip for **each** distinct non-base token, not a single whole-cycle measurement) and
+**drops** any candidate whose tokens include a honeypot / sell-blocked / over-taxed /
+max-tx-limited one. Dropped candidates are **never sized, never fired**, and the
+drop count surfaces in the verdict (`token-safety dropped : N`). On a fresh-pool run a high drop
+rate is **expected and healthy** — long-tail pools are full of unsellable tokens.
+
 A run is **KILL** if **any** of these trip:
 
 1. **Margin too thin** — median net-of-gas profit per profitable op `< minNetProfitToFrictionRatio ×` friction.
@@ -62,12 +70,15 @@ treat a backtest Sharpe > 3 as overfitting rather than success.
 |------|------|--------------|--------------|
 | 0 Data plane | *(external)* | Self-host a Reth/Erigon archive node per chain so live + historical reads are byte-identical; commercial RPC only as fallback. | TODO (ops): see below. |
 | 1 Scanner | `scanner.js` | Enumerate V2-fork pairs per factory, snapshot reserves + **per-fork** fee to a JSON pool snapshot. | `getReserves()/token0()/token1()` are **real** ethers v6 calls. Full enumeration (PairCreated replay / `allPairs(i)` + Multicall3) is **TODO**. |
+| **1b Fresh-pool scanner** | `freshPoolScanner.js` | **PLAY #3.** Replay `PairCreated` logs over a recent block window, keep pools **younger than `maxAgeBlocks`**, snapshot reserves, and emit the **same snapshot shape** as `scanner.js` PLUS per-pool `createdBlock`/`ageBlocks`/`competitorCount`. Feeds the long-tail / fresh-pool backrun on a PGA chain. | `getLogs(PairCreated)` decode + age filter + reserve reads are **real** ethers v6 calls. getLogs range **chunking under provider caps + Multicall3** batching are **TODO** (same surface as `scanner.js`). |
 | 2 Path-finder | `pathfinder.js` | Build the token graph, run Bellman-Ford **negative-cycle** detection seeded at baseToken to surface round-trip candidates (2–5 hops). **Pure function over a snapshot** → testable offline. | Real, working candidate generator. Exhaustive enumeration (Johnson / line-graph MMBF) is a noted upgrade. |
-| 3 Sizing + net-of-gas | `backtester.js` | Size each cycle to its optimal input, simulate CPMM output, subtract per-hop fees **and** gas+priority fee priced for **both** the fat and lean executors. | Real CPMM math. **revm/Anvil re-simulation against historical state is TODO** (without it, pure formulas overstate profit). |
-| 4 Paper-trade + KILL/GO | `backtester.js` | Apply explicit kill-criteria, emit the verdict + stats. | Real. Win-rate/revert come from config until live-shadow + revm provide measured values. |
+| **3-gate Token-safety** | `tokenSafety.js` | **PLAY #4 (highest priority).** A **per-token `base->token->base` buy-then-sell probe** (run independently for **each** non-base token, NOT a single whole-cycle measurement) that flags honeypots / sell-blocks / fee-on-transfer / transfer-tax / max-tx limits / post-launch fee-flips. Wired as a **HARD pre-fire GATE** in `backtester.runBacktest`: a candidate is **dropped and never fired** (and counted) if **any** of its tokens fails. Interface: `{ safe, reasons[], measuredSellTax, honeypot, maxTxSuspected, feeFlipRisk, fidelity }`. | **Real** per-token `eth_call` `getAmountsOut` base<->token round-trip approximation + clean-CPMM base<->token baseline + classifier. The honeypot/sell-revert signal needs no baseline (covers interior tokens too); the **exact forked-EVM buy-then-sell** (anvil/foundry/revm, state-override funding) is **TODO** (the `simulateOnFork` seam self-reports unimplemented). |
+| 3 Sizing + net-of-gas | `backtester.js` + `sizing.js` | Size each **safe** cycle with the **liquidity-capped CPMM optimal-input sizer** (hard-capped by `reserveCapFraction` × thinnest hop reserve **and** a `maxPriceImpactBps` budget), simulate CPMM output, subtract per-hop fees **and** gas+priority fee priced for **both** the fat and lean executors. | Real CPMM math + real capped sizing (no naive sizing). **revm/Anvil re-simulation against historical state is TODO** (without it, pure formulas overstate profit). |
+| 4 Paper-trade + KILL/GO | `backtester.js` | Apply explicit kill-criteria, emit the verdict + stats (now including `tokenSafetyDropped`). | Real. Win-rate/revert come from config until live-shadow + revm provide measured values. |
+| — Gas-bid policy | `gasBidPolicy.js` | **PLAY #3.** Dynamic **priority-gas-auction** bid policy for Monad/HyperEVM: bid just above the marginal competitor, never above `maxBidFraction` × expected profit, **decline** when the auction has bid the EV away. Pure + testable. | Real, pure policy. A **live mempool competitor feed** to source `competitorBidGwei` is **TODO**. |
 | — Gas model | `gasModel.js` | Documented per-hop gas constants for **this** executor vs a **lean** target so the strip decision is data-driven. | Constants are **PLACEHOLDERS** — replace with measured `REPORT_GAS` numbers. |
 | — Config | `config.js` | Loads config, resolves RPC from **env vars only**, reuses `scripts/utils/addresses.js` for base tokens/factories, warns on address drift. | Real. |
-| — Runner | `run.js` | Offline orchestrator: runs Stage 2→4 over an existing/`--demo` snapshot with zero RPC. | Real. |
+| — Runner | `run.js` | Offline orchestrator: runs Stage 1b→4 over an existing/`--demo` snapshot with zero RPC. | Real. |
 
 ## Configure
 
@@ -100,6 +111,93 @@ identical state. Use QuickNode/Alchemy/Chainstack/Dwellir only to bootstrap. Bat
 **Multicall3** (`0xcA11bde05977b3631167028862bE2a173976CA11`, already in the config). This
 step has no code here on purpose — it is infra.
 
+## PLAY #4 — token-safety guard (the gate that makes the fresh-pool play survivable)
+
+`tokenSafety.js` runs a **per-token base<->token probe** — the 2-hop round-trip that actually
+loses you money, measured **one token at a time** (NOT across a whole multi-hop cycle):
+
+```
+buy  baseToken --(base<->token pool)-->  token       (amountToken)
+sell token     --(base<->token pool)-->  baseToken   (amountBaseBack)
+```
+
+This is deliberately scoped: a single 2-hop `base->token->base` probe is valid only for that
+one token's direct base pool, so it is **never** treated as the round-trip tax of a longer
+(3–5 hop) candidate. To make a multi-hop candidate safe, the GATE runs this probe
+**independently for each distinct non-base token** on the path and drops the candidate if **any**
+one fails (see `backtester.gateTokenSafety` / `tokenSafetyTargets`).
+
+A clean token returns `amountBaseBack` ≈ input minus only the two V2 swap fees + price impact.
+The guard computes the **clean CPMM base<->token baseline** (same math the backtester trusts, on
+the **same** base<->token pool it quotes) and compares it to what the chain actually returns via
+a real per-token `eth_call getAmountsOut([base,token])` then `getAmountsOut([token,base])`. The
+residual, net of the fees already accounted for, is the **measured sell/transfer tax**. A
+**revert on the sell leg** (with a healthy buy) is the honeypot signature — and that signal needs
+**no baseline**, so it gates interior tokens of a longer cycle too. A tax that **jumps at a larger
+probe size** flags a max-tx / anti-whale / graduated-launch tax. A **live owner** that could flip
+fees post-launch is a soft `feeFlipRisk` (never a hard fail by itself).
+
+**Interface (stable across fidelity levels):**
+`checkToken(...) -> { safe, reasons[], measuredSellTax, honeypot, maxTxSuspected, feeFlipRisk, fidelity }`.
+
+- **`fidelity: 'eth_call'`** — the implemented approximation (real per-token `getAmountsOut`
+  over the `base<->token` 2-hop path). Catches sell-reverts (honeypots), pair-applied taxes, and
+  size-dependent gates. It measures **one token's direct base round-trip**, not the full cycle;
+  the measured tax is meaningful only for a token directly paired with base (the clean baseline
+  is the same base<->token pool). Interior tokens with no direct base pool on the cycle still get
+  the baseline-free honeypot/sell-revert check; an offline tax baseline for them (their real
+  base<->token reserves) is a **TODO** (needs a pool lookup / RPC).
+- **`fidelity: 'fork'`** — **TODO**: the exact buy-then-sell on a forked EVM (anvil/foundry/revm)
+  that funds a throwaway EOA via state override and actually executes both legs. Only this catches
+  holder-state / `tx.origin` / whitelist honeypots a stateless quote misses. `simulateOnFork()` is
+  the seam and self-reports `implemented:false` so a number is never trusted that wasn't produced.
+- **`fidelity: 'offline'`** — pure classification from injected/precomputed round-trips (tests/demo).
+
+**Wired as a HARD gate:** `backtester.runBacktest` calls `gateTokenSafety` **before** sizing.
+Unsafe candidates are dropped and counted (`tokenSafetyDropped`); they are **never sized or fired**.
+Configure via `config.tokenSafety` (`router`, `maxSellTax`, `largeProbeMultiplier`, …).
+
+## PLAY #3 — long-tail / fresh-pool backrun on a Priority-Gas-Auction chain
+
+The durable edge in 2026 is **not** contesting the same fat pools every searcher watches — it's
+being **first into a brand-new V2-fork pool** the moment liquidity lands, on a **thin, fast,
+under-contested PGA chain (Monad / HyperEVM)** where inclusion is bought openly via the priority
+fee (no sealed-bid OFA to plug into).
+
+Three pieces implement this:
+
+1. **`freshPoolScanner.js`** — replays `PairCreated` logs over a recent block window and keeps only
+   pools **younger than `maxAgeBlocks`**. The creation block gives **freshness for free**. Output is
+   a strict **superset** of a `scanner.js` snapshot (adds `createdBlock`, `ageBlocks`,
+   `competitorCount` = #other pairs born in the same block on the same factory), so
+   `pathfinder.js` + `backtester.js` consume it **unchanged**. Writes `snapshot.<chain>.fresh.json`.
+2. **`sizing.js` (`optimalInputCapped`)** — the backtester now sizes every cycle with a
+   **liquidity-capped** optimum: hard-capped by `reserveCapFraction` × the **thinnest** hop's
+   reserve **and** by the largest size whose cumulative round-trip impact stays under
+   `maxPriceImpactBps`. This replaces the old naive first-hop-reserve cap, which over-sizes
+   catastrophically in thin fresh pools. The report shows which cap bound the size (`sizeBoundBy`).
+3. **`gasBidPolicy.js`** — the PGA bid policy: bid just above the marginal competitor
+   (`outbidIncrement`), never above `maxBidFraction` × expected profit, floor at the chain minimum,
+   and **decline** the op entirely when winning would cost more than the EV (`shouldBid → false`).
+   Pure functions (`computeBid`, `shouldBid`, `profitToMaxBidGwei`) — unit-test targets.
+
+### ⚠️ GATE-0 (must verify LIVE before any deploy/bond)
+
+Chainlink **acquired Atlas (22 Jan 2026)** and pivoted toward SVR-liquidation flow. The
+permissionless DEX-backrun OFA's continued openness — and that your chosen PGA chain is genuinely
+**under-contested** — **MUST be verified with a live-shadow run before bonding any capital.** The
+toolkit **signs nothing**; treat every `GO` as provisional until live-shadow + the forked-EVM
+re-sim (Stage 3 ground truth) measure a real win-rate and revert rate.
+
+### Monad / HyperEVM config
+
+`monad` and `hyperevm` entries are added to `config.example.json` **disabled, with PLACEHOLDER
+chainId / factory / wrapped-native addresses** — they are **not** in `scripts/utils/addresses.js`,
+so `config.js` resolves their base token to `null`. **You must fill the real addresses + per-fork
+`feeBps` from each chain's docs and verify them on-chain before enabling.** Tune `freshScan`
+(`lookbackBlocks`, `maxAgeBlocks`) to the chain's block time — a few thousand blocks is *minutes*
+on a fast PGA chain.
+
 ## Run each stage
 
 ```bash
@@ -109,6 +207,13 @@ node research/run.js --demo
 # Stage 1: scan configured chains -> writes research/data/snapshot.<chain>.json
 #   (needs RPC env vars + "seedPairs" in config until full enumeration is implemented)
 node research/scanner.js
+
+# Stage 1b (PLAY #3): fresh-pool scan via PairCreated replay -> snapshot.<chain>.fresh.json
+#   (needs RPC env vars; keeps only pools younger than freshScan.maxAgeBlocks)
+node research/freshPoolScanner.js
+
+# Stage 1b->4: replay a fresh-pool snapshot through path-finder + token-safety gate + backtester
+node research/run.js research/data/snapshot.bsc.fresh.json
 
 # Stage 2-4: replay an existing snapshot through path-finder + backtester
 node research/run.js research/data/snapshot.bsc.json
@@ -140,8 +245,13 @@ just *present once*.
 4. **Live-shadow mode** — run the scanner for weeks signing **nothing**, log every would-be
    op, inspect the next block to see if a competitor took it / it would have reverted →
    measures the real **win-rate** and **revert rate** that the kill-criteria need.
-5. **Token-safety layer** — `eth_call` revert-guard + honeypot/transfer-tax heuristics before
-   any path is counted profitable (long-tail pools are full of unsellable tokens).
+5. **Token-safety layer** — **DONE (eth_call tier):** `tokenSafety.js` runs a **per-token
+   `base->token->base`** buy-then-sell probe wired as a HARD pre-fire gate in the backtester (each
+   non-base token checked independently; honeypot/sell-revert needs no baseline). **Remaining
+   TODO:** an offline tax baseline for **interior** tokens (their real base<->token reserves, via
+   a pool lookup), the exact **forked-EVM** buy-then-sell (`simulateOnFork` seam) to catch
+   holder-state / `tx.origin` honeypots a stateless quote misses, plus temporal **fee-flip**
+   detection (replay setter history).
 
 ## What this toolkit deliberately is NOT
 

--- a/research/backtester.js
+++ b/research/backtester.js
@@ -26,6 +26,8 @@
 const { ethers } = require('ethers');
 const { getAmountOut } = require('./pathfinder.js');
 const { gasCostForCycle, compareExecutors } = require('./gasModel.js');
+const { optimalInputCapped } = require('./sizing.js');
+const { checkToken } = require('./tokenSafety.js');
 
 /**
  * Simulate a full round-trip cycle for a given input amount.
@@ -43,76 +45,44 @@ function simulateCycle(amountIn, hops) {
 }
 
 /**
- * Find a near-optimal input size by golden-section-free coarse+refine search.
- * (A closed-form optimum exists for 2-pool cycles and is extendable hop-by-hop — TODO to
- * implement exactly; this bounded search is robust for the skeleton and >2 hops.)
+ * Find a near-optimal input size, HARD-CAPPED by pool reserves and a max-price-impact budget.
  *
- * Profit(x) = simulateCycle(x) - x is unimodal in x for CPMM cycles, so a ternary/grid
- * search converges. We grid-search in log space then refine around the best point.
+ * This now delegates to sizing.optimalInputCapped (PLAY #3): the old version capped only at
+ * the FIRST hop's reserve and ignored price impact, which over-sizes catastrophically in thin
+ * fresh pools. The capped sizer bounds the input by (a) reserveCapFraction × the THINNEST
+ * hop's input reserve and (b) the largest size whose cumulative round-trip impact stays under
+ * maxPriceImpactBps, then maximises gross profit (unimodal grid+ternary) inside that interval.
+ *
+ * Backward-compatible shape: returns { amountIn, amountOut, grossProfitWei } plus extra
+ * cap/impact fields the evaluator surfaces. `opts.sizingCfg` overrides the sizing knobs
+ * (config.sizing). `opts.maxInputWei` (legacy) further tightens the reserve cap if smaller.
  *
  * @param {Array<object>} hops
- * @param {{ maxInputWei?: bigint }} [opts]
- * @returns {{ amountIn: bigint, amountOut: bigint, grossProfitWei: bigint }}
+ * @param {{ maxInputWei?: bigint, sizingCfg?: object }} [opts]
+ * @returns {{ amountIn:bigint, amountOut:bigint, grossProfitWei:bigint,
+ *   reserveCapWei:bigint, impactCapWei:bigint, hardCapWei:bigint,
+ *   priceImpactBps:number, boundBy:string }}
  */
 function optimalInput(hops, opts = {}) {
-  if (!hops || hops.length === 0) return { amountIn: 0n, amountOut: 0n, grossProfitWei: 0n };
-
-  // Upper bound: a fraction of the smallest base-side reserve on the first hop keeps us in
-  // the regime where the cycle can be profitable (huge size always self-destructs via impact).
-  const firstReserveIn = BigInt(hops[0].reserveIn);
-  // Cap the search at the first hop's base-side reserve: trading more than the pool holds
-  // is always self-defeating (price impact dominates). The true optimum is typically a
-  // small fraction of this, so the grid below is GEOMETRIC (log-spaced) to sample the
-  // profitable low region densely instead of wasting points on the deep-negative high end.
-  const hardCap = opts.maxInputWei || firstReserveIn;
-  if (hardCap <= 0n) return { amountIn: 0n, amountOut: 0n, grossProfitWei: 0n };
-
-  const profitAt = (x) => {
-    if (x <= 0n) return -1n;
-    const out = simulateCycle(x, hops);
-    return out - x;
-  };
-
-  // Geometric grid over [lo, hardCap]: x_i = lo * (hardCap/lo)^(i/steps). Profit(x) is
-  // unimodal for a CPMM cycle, so the grid brackets the optimum; we refine with ternary.
-  const lo = hardCap / 100000000n > 0n ? hardCap / 100000000n : 1n;
-  const steps = 80;
-  const loF = Number(lo);
-  const ratio = Number(hardCap) / loF; // hardCap/lo as a float for exponent spacing
-  let best = { amountIn: lo, profit: profitAt(lo) };
-  for (let i = 1; i <= steps; i++) {
-    const xF = loF * Math.pow(ratio, i / steps);
-    const x = BigInt(Math.max(1, Math.round(xF)));
-    const p = profitAt(x);
-    if (p > best.profit) best = { amountIn: x, profit: p };
+  if (!hops || hops.length === 0) {
+    return {
+      amountIn: 0n, amountOut: 0n, grossProfitWei: 0n,
+      reserveCapWei: 0n, impactCapWei: 0n, hardCapWei: 0n, priceImpactBps: 0, boundBy: 'interior'
+    };
   }
-
-  // Ternary refine in the bracket [best/4, best*4] (clamped), where Profit is unimodal.
-  let left = best.amountIn / 4n > 0n ? best.amountIn / 4n : 1n;
-  let right = best.amountIn * 4n < hardCap ? best.amountIn * 4n : hardCap;
-  for (let iter = 0; iter < 200 && right - left > 1n; iter++) {
-    const third = (right - left) / 3n;
-    const m1 = left + third;
-    const m2 = right - third;
-    if (profitAt(m1) < profitAt(m2)) {
-      left = m1 + 1n;
-    } else {
-      right = m2;
+  const sized = optimalInputCapped(hops, opts.sizingCfg || {});
+  // Legacy explicit ceiling (API stability): if the caller passed a tighter maxInputWei than
+  // the sizer's chosen optimum, clamp the input down to it and recompute the output. Profit(x)
+  // is unimodal and the cap sits left of the optimum, so the clamped point is the best feasible
+  // input under the explicit ceiling.
+  if (opts.maxInputWei) {
+    const cap = BigInt(opts.maxInputWei);
+    if (cap > 0n && sized.amountIn > cap) {
+      const out = simulateCycle(cap, hops);
+      return { ...sized, amountIn: cap, amountOut: out, grossProfitWei: out - cap, hardCapWei: cap, boundBy: 'explicit' };
     }
   }
-  // Pick the best of {grid winner, refined endpoints}.
-  const candidatesX = [best.amountIn, left, right];
-  let xStar = candidatesX[0];
-  let pStar = profitAt(xStar);
-  for (const x of candidatesX.slice(1)) {
-    const p = profitAt(x);
-    if (p > pStar) {
-      pStar = p;
-      xStar = x;
-    }
-  }
-  const outStar = simulateCycle(xStar, hops);
-  return { amountIn: xStar, amountOut: outStar, grossProfitWei: outStar - xStar };
+  return sized;
 }
 
 /**
@@ -133,15 +103,17 @@ function weiToUsd(wei, nativeUsdPrice) {
 }
 
 /**
- * Evaluate a single candidate cycle: size it, simulate, and net out gas for BOTH executors.
+ * Evaluate a single candidate cycle: size it (liquidity- + impact-capped), simulate, and net
+ * out gas for BOTH executors.
  * @param {object} candidate - { tokens, hops, marginalEdgePct }.
  * @param {object} gasCfg - config.gas.
+ * @param {object} [sizingCfg] - config.sizing (reserveCapFraction, maxPriceImpactBps).
  * @returns {object} evaluation record.
  */
-function evaluateCandidate(candidate, gasCfg) {
+function evaluateCandidate(candidate, gasCfg, sizingCfg = {}) {
   const hops = candidate.hops;
   const hopCount = hops.length;
-  const sized = optimalInput(hops);
+  const sized = optimalInput(hops, { sizingCfg });
 
   const grossUsd = weiToUsd(sized.grossProfitWei, gasCfg.nativeUsdPrice);
   const gasFat = gasCostForCycle(hopCount, gasCfg, 'bofhV2');
@@ -158,6 +130,11 @@ function evaluateCandidate(candidate, gasCfg) {
     amountOutWei: sized.amountOut.toString(),
     grossProfitWei: sized.grossProfitWei.toString(),
     grossUsd,
+    // PLAY #3 sizing transparency: which constraint bound the size + realised impact.
+    sizeBoundBy: sized.boundBy,
+    priceImpactBps: sized.priceImpactBps,
+    reserveCapWei: sized.reserveCapWei.toString(),
+    impactCapWei: sized.impactCapWei.toString(),
     gasUsdFat: gasFat.costUsd,
     gasUsdLean: gasLean.costUsd,
     netUsdFat,
@@ -168,6 +145,139 @@ function evaluateCandidate(candidate, gasCfg) {
     profitableLean: netUsdLean > 0,
     onlyLeanProfitable: netUsdLean > 0 && netUsdFat <= 0
   };
+}
+
+/**
+ * For a candidate cycle, enumerate EACH distinct non-base token T and (where derivable) a
+ * clean-CPMM base<->token baseline for the token-safety guard's PER-TOKEN probe (PLAY #4).
+ *
+ * SEMANTICS FIX (was apples-to-oranges): the token-safety probe is a 2-hop base<->token
+ * round-trip (base->T->base), NOT a measurement over a whole >2-hop cycle. So a token's
+ * baseline must come from a hop that pairs T DIRECTLY with the base token, never from interior
+ * token-to-token hops of a longer cycle (those are different pools with their own fee/impact —
+ * comparing the live base<->token quote against them would fabricate a meaningless "tax").
+ *
+ *   - buyPool  is set ONLY from a hop base->T  (from===base, to===T).
+ *   - sellPool is set ONLY from a hop T->base  (from===T,   to===base).
+ * If a token is paired directly with base on the cycle (the typical first/last leg of a
+ * baseToken-anchored cycle), both are available and tax is measurable apples-to-apples. For an
+ * INTERIOR token with no direct base pairing on this cycle, we have no base<->token reserves
+ * offline → buyPool/sellPool are left null. The guard then SKIPS the (unmeasurable) tax math
+ * for that token but STILL runs the live honeypot / sell-revert probe (which needs no baseline
+ * and applies to every non-base token regardless of cycle position). Obtaining the interior
+ * token's real base<->token reserves for an offline tax baseline is a TODO (needs a pool
+ * lookup / RPC); live mode covers the honeypot signal today.
+ *
+ * @param {object} candidate - { tokens, hops }.
+ * @param {string} baseToken
+ * @returns {Array<{ token:string, buyPool:(object|null), sellPool:(object|null), directBasePair:boolean }>}
+ */
+function tokenSafetyTargets(candidate, baseToken) {
+  const hops = candidate.hops;
+  const baseKey = baseToken.toLowerCase();
+  const out = [];
+  // A token T's base<->token BUY pool is a hop base->T; its base<->token SELL pool is T->base.
+  const buyFromBase = new Map(); // T -> hop (base -> T)
+  const sellToBase = new Map(); // T -> hop (T -> base)
+  for (const h of hops) {
+    const fromKey = h.from.toLowerCase();
+    const toKey = h.to.toLowerCase();
+    if (fromKey === baseKey && toKey !== baseKey) buyFromBase.set(toKey, h);
+    if (toKey === baseKey && fromKey !== baseKey) sellToBase.set(fromKey, h);
+  }
+  const seen = new Set();
+  for (const h of hops) {
+    for (const t of [h.from, h.to]) {
+      const key = t.toLowerCase();
+      if (key === baseKey || seen.has(key)) continue;
+      seen.add(key);
+      const buyHop = buyFromBase.get(key);
+      const sellHop = sellToBase.get(key);
+      const directBasePair = !!(buyHop && sellHop);
+      out.push({
+        token: t,
+        // BUY pool (base->T): base-side=reserveIn, token-side=reserveOut. Null unless T is
+        // directly paired with base on this cycle (apples-to-apples baseline requirement).
+        buyPool: directBasePair
+          ? { reserveBase: BigInt(buyHop.reserveIn), reserveToken: BigInt(buyHop.reserveOut), feeBps: buyHop.feeBps }
+          : null,
+        // SELL pool (T->base): token-side=reserveIn, base-side=reserveOut.
+        sellPool: directBasePair
+          ? { reserveToken: BigInt(sellHop.reserveIn), reserveBase: BigInt(sellHop.reserveOut), feeBps: sellHop.feeBps }
+          : null,
+        directBasePair
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * HARD token-safety GATE (PLAY #4) applied BEFORE a candidate is evaluated/fired.
+ *
+ * For EACH distinct non-base token on the cycle, run the PER-TOKEN base<->token buy-then-sell
+ * probe (tokenSafety.checkToken) INDEPENDENTLY. A candidate is DROPPED if ANY one of its
+ * tokens fails (honeypot / sell-block / over-limit transfer tax / max-tx). This is a per-token
+ * 2-hop probe, not a single whole-cycle measurement: a 3–5 hop cycle is only as safe as its
+ * most dangerous token, and the honeypot/sell-revert signal (which needs no CPMM baseline)
+ * covers interior tokens too. Dropped candidates are COUNTED and never evaluated.
+ *
+ * MODES:
+ *  - Live: pass `opts.provider` (+ `opts.router` for getAmountsOut). The guard runs the real
+ *    eth_call round-trip per token. This is async.
+ *  - Offline (demo/tests): with no provider, the guard has no real round-trip data, so by
+ *    policy it does NOT hard-fail clean tokens (it only fails on POSITIVE evidence). This keeps
+ *    the offline pipeline runnable while the gate is fully active the moment a provider is
+ *    wired. An optional `opts.injectedSafety` map (tokenAddr->precomputed) lets tests drive
+ *    deterministic failures through the SAME code path.
+ *
+ * @param {object[]} candidates
+ * @param {string} baseToken
+ * @param {object} [opts] - { provider, router, tokenSafetyCfg, probeAmountInWei, injectedSafety }
+ * @returns {Promise<{ safe:object[], dropped:object[], byToken:object[] }>}
+ */
+async function gateTokenSafety(candidates, baseToken, opts = {}) {
+  const safe = [];
+  const dropped = [];
+  const byToken = [];
+  if (!baseToken) {
+    // Without a base token we can't orient buy/sell pools; pass through but flag.
+    return { safe: candidates.slice(), dropped: [], byToken: [{ note: 'no baseToken — token-safety gate skipped' }] };
+  }
+  const probeAmount = opts.probeAmountInWei ? BigInt(opts.probeAmountInWei) : (10n ** 18n) / 100n; // 0.01 base default
+
+  for (const cand of candidates) {
+    const targets = tokenSafetyTargets(cand, baseToken);
+    let candSafe = true;
+    const candReasons = [];
+    for (const tgt of targets) {
+      const injected = opts.injectedSafety ? opts.injectedSafety[tgt.token.toLowerCase()] : undefined;
+      const res = await checkToken(
+        {
+          provider: opts.provider,
+          router: opts.router,
+          baseToken,
+          token: tgt.token,
+          amountIn: probeAmount,
+          buyPool: tgt.buyPool,
+          sellPool: tgt.sellPool,
+          precomputed: injected
+        },
+        opts.tokenSafetyCfg || {}
+      );
+      byToken.push({ token: tgt.token, safe: res.safe, measuredSellTax: res.measuredSellTax, fidelity: res.fidelity, reasons: res.reasons });
+      if (!res.safe) {
+        candSafe = false;
+        candReasons.push(`${tgt.token}: ${res.reasons.join('; ')}`);
+      }
+    }
+    if (candSafe) {
+      safe.push(cand);
+    } else {
+      dropped.push({ candidate: cand, reasons: candReasons });
+    }
+  }
+  return { safe, dropped, byToken };
 }
 
 /**
@@ -182,12 +292,14 @@ function evaluateCandidate(candidate, gasCfg) {
  *
  * @param {object[]} evals - evaluateCandidate() records.
  * @param {object} killCfg - config.kill.
- * @param {{ windowDays?: number, revertRate?: number }} [obs] - observed run stats.
+ * @param {{ windowDays?: number, revertRate?: number, tokenSafetyDropped?: number,
+ *          candidatesBeforeSafety?: number }} [obs] - observed run stats.
  * @returns {object} verdict report.
  */
 function applyKillCriteria(evals, killCfg, obs = {}) {
   const reasons = [];
   const windowDays = obs.windowDays || 1;
+  const tokenSafetyDropped = obs.tokenSafetyDropped || 0;
 
   const profitableFat = evals.filter((e) => e.profitableFat);
   const profitableLean = evals.filter((e) => e.profitableLean);
@@ -246,6 +358,16 @@ function applyKillCriteria(evals, killCfg, obs = {}) {
     );
   }
 
+  // Token-safety GATE result (PLAY #4). Dropped candidates never reach evaluation; this is
+  // informational in the verdict (the drop already happened). A high drop rate on a fresh-pool
+  // run is EXPECTED — long-tail pools are full of honeypots — and proves the gate is working.
+  if (tokenSafetyDropped > 0) {
+    reasons.push(
+      `INFO: token-safety GATE dropped ${tokenSafetyDropped} candidate(s) (honeypot / sell-block ` +
+        '/ transfer-tax / max-tx) BEFORE evaluation. Never fired.'
+    );
+  }
+
   // Representativeness gate
   if (opportunitiesPerDay < (killCfg.minOpportunitiesPerDay || 0)) {
     reasons.push(
@@ -262,6 +384,8 @@ function applyKillCriteria(evals, killCfg, obs = {}) {
     reasons,
     stats: {
       candidates: evals.length,
+      candidatesBeforeSafety: obs.candidatesBeforeSafety ?? evals.length,
+      tokenSafetyDropped,
       profitableFat: profitableFat.length,
       profitableLean: profitableLean.length,
       medianNetUsdFat: medianNetFat,
@@ -274,22 +398,45 @@ function applyKillCriteria(evals, killCfg, obs = {}) {
 }
 
 /**
- * Full Stage 3+4 run over a snapshot + candidates. Pure (no I/O) so it is unit-testable.
+ * Full Stage 3+4 run over a snapshot + candidates.
+ *
+ * PIPELINE ORDER (PLAY #4 gate enforced):
+ *   candidates --[token-safety GATE]--> safe candidates --[size+net-of-gas]--> evals --[KILL/GO]
+ * Candidates failing token-safety are DROPPED here and never evaluated or fired; the drop
+ * count flows into the verdict stats. The gate is async (it may eth_call an RPC); in offline
+ * mode it is a no-op pass-through unless `obs.injectedSafety` drives deterministic failures.
+ *
  * @param {object} snapshot
  * @param {object[]} candidates - from pathfinder.findCandidateCycles().
- * @param {object} config - full research config (uses .gas and .kill).
- * @param {{ windowDays?: number, winRate?: number, revertRate?: number }} [obs]
- * @returns {{ evals: object[], report: object, executorComparisonSample: object }}
+ * @param {object} config - full research config (uses .gas, .kill, .sizing, .tokenSafety).
+ * @param {{ windowDays?: number, winRate?: number, revertRate?: number,
+ *          provider?: object, router?: string, injectedSafety?: object }} [obs]
+ * @returns {Promise<{ evals:object[], report:object, executorComparisonSample:object, safety:object }>}
  */
-function runBacktest(snapshot, candidates, config, obs = {}) {
+async function runBacktest(snapshot, candidates, config, obs = {}) {
   const gasCfg = config.gas || {};
   const killCfg = config.kill || {};
-  const evals = candidates.map((c) => evaluateCandidate(c, gasCfg));
-  const report = applyKillCriteria(evals, killCfg, obs);
+  const sizingCfg = config.sizing || {};
+
+  // Stage-3 PRE-FIRE token-safety GATE (PLAY #4): drop unsafe candidates before any sizing.
+  const safety = await gateTokenSafety(candidates, snapshot.baseToken, {
+    provider: obs.provider,
+    router: obs.router || (config.tokenSafety && config.tokenSafety.router),
+    tokenSafetyCfg: config.tokenSafety || {},
+    injectedSafety: obs.injectedSafety
+  });
+  const safeCandidates = safety.safe;
+
+  const evals = safeCandidates.map((c) => evaluateCandidate(c, gasCfg, sizingCfg));
+  const report = applyKillCriteria(evals, killCfg, {
+    ...obs,
+    tokenSafetyDropped: safety.dropped.length,
+    candidatesBeforeSafety: candidates.length
+  });
   // Head-to-head fat-vs-lean gas at a representative hop count, for the strip decision.
   const sampleHops = evals.length ? evals[0].hopCount : 3;
   const executorComparisonSample = compareExecutors(sampleHops, gasCfg);
-  return { evals, report, executorComparisonSample };
+  return { evals, report, executorComparisonSample, safety };
 }
 
 /**
@@ -301,6 +448,8 @@ function printReport(result) {
   const { evals, report, executorComparisonSample } = result;
   const line = '='.repeat(72);
   console.log(`\n${line}\nPAPER-TRADE REPORT (net-of-gas) — Stage 4 KILL/GO\n${line}`);
+  console.log(`candidates (pre-gate): ${report.stats.candidatesBeforeSafety}`);
+  console.log(`token-safety dropped : ${report.stats.tokenSafetyDropped}`);
   console.log(`candidates evaluated : ${report.stats.candidates}`);
   console.log(`profitable (fat V2)  : ${report.stats.profitableFat}`);
   console.log(`profitable (lean)    : ${report.stats.profitableLean}`);
@@ -326,6 +475,8 @@ module.exports = {
   simulateCycle,
   optimalInput,
   weiToUsd,
+  tokenSafetyTargets,
+  gateTokenSafety,
   evaluateCandidate,
   applyKillCriteria,
   runBacktest,

--- a/research/config.example.json
+++ b/research/config.example.json
@@ -23,12 +23,73 @@
     "snapshotOutPath": "research/data/snapshot.json"
   },
 
+  "freshScan": {
+    "_comment": [
+      "Stage-1b FRESH-POOL scanner (PLAY #3). Replays PairCreated logs over a recent block",
+      "window and keeps only pools younger than maxAgeBlocks. Emits the SAME snapshot shape",
+      "as scanner.js PLUS per-pool createdBlock/ageBlocks/competitorCount fields (additive;",
+      "downstream stages ignore unknown keys). competitorCount = #other pairs created in the",
+      "same block on the same factory (crude contention proxy). Tune to the chain's block time:",
+      "on a fast PGA chain (Monad/HyperEVM) a few thousand blocks is minutes, not hours."
+    ],
+    "lookbackBlocks": 5000,
+    "maxAgeBlocks": 1500,
+    "maxBlockSpan": 2000,
+    "maxFreshPerFactory": 500,
+    "snapshotOutPath": "research/data/snapshot.json"
+  },
+
   "pathfinder": {
     "_comment": "Stage-2 negative-cycle search knobs. Mirrors contract MAX_PATH_LENGTH=5.",
     "maxHops": 5,
     "minHops": 2,
     "minEdgeReserveBaseToken": "1.0",
     "topN": 50
+  },
+
+  "sizing": {
+    "_comment": [
+      "Stage-3 liquidity-capped CPMM optimal-input sizing (PLAY #3). Replaces naive sizing:",
+      "the input is HARD-CAPPED by (a) reserveCapFraction x the THINNEST hop's input reserve",
+      "and (b) the largest size whose cumulative round-trip price impact stays under",
+      "maxPriceImpactBps, then gross profit is maximised inside that interval. Protects against",
+      "over-sizing into thin fresh pools (a CPMM-only optimum craters the pool)."
+    ],
+    "reserveCapFraction": 0.3,
+    "maxPriceImpactBps": 300,
+    "gridSteps": 80
+  },
+
+  "tokenSafety": {
+    "_comment": [
+      "Stage-3 PRE-FIRE token-safety GATE (PLAY #4 — highest priority). A buy-then-sell",
+      "round-trip simulation flags honeypots / sell-blocks / fee-on-transfer / transfer-tax /",
+      "max-tx / post-launch fee-flips. A candidate failing the gate is DROPPED and never fired.",
+      "`router` is a V2 router for getAmountsOut quoting (live mode); set per chain. The exact",
+      "forked-EVM buy-then-sell is TODO (needs anvil/foundry/revm) — the eth_call approximation",
+      "runs today. Offline (no provider) the gate is pass-through unless a precomputed map is fed."
+    ],
+    "router": "",
+    "maxSellTax": 0.10,
+    "probeReserveFraction": 0.001,
+    "largeProbeMultiplier": 25,
+    "taxConsistencyTolerance": 0.03,
+    "treatSellQuoteFailureAsHoneypot": true
+  },
+
+  "gasBid": {
+    "_comment": [
+      "PLAY #3 PRIORITY-GAS-AUCTION bid policy for Monad/HyperEVM. There is NO sealed-bid OFA",
+      "on these chains — inclusion is bought openly via the priority fee. Bid just above the",
+      "marginal competitor (outbidIncrement), never above maxBidFraction x expected profit, and",
+      "DECLINE when the auction has bid the EV away. All gwei. Pure/testable (gasBidPolicy.js)."
+    ],
+    "maxBidFraction": 0.5,
+    "outbidIncrement": 1.05,
+    "minOutbidGwei": 0.01,
+    "assumedGasUnits": 150000,
+    "minPriorityGwei": 0.0,
+    "absMaxPriorityGwei": 5000.0
   },
 
   "gas": {
@@ -90,6 +151,49 @@
       "factories": {
         "QuickSwapV2": { "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32", "feeBps": 30 },
         "SushiSwapV2": { "address": "0xc35DADB65012eC5796536bD9864eD8773aBc74C4", "feeBps": 30 }
+      }
+    },
+
+    "_pgaChainsComment": [
+      "PLAY #3 PRIORITY-GAS-AUCTION targets. These thin / fast / under-contested chains are",
+      "where the fresh-pool V2-fork backrun edge plausibly survives: no sealed-bid OFA, so",
+      "inclusion is an open priority-fee auction (gasBidPolicy.js). They are NOT in",
+      "scripts/utils/addresses.js, so config.js resolveBaseToken returns null — you MUST set",
+      "the wrapped-native + factory addresses below from each chain's own docs before enabling.",
+      "All values are PLACEHOLDERS / TODO: verify chainId, factory address, per-fork feeBps, and",
+      "the wrapped-native token on-chain. Left disabled on purpose. GATE-0 still applies: verify",
+      "the chosen chain is genuinely under-contested with a live-shadow run before bonding."
+    ],
+
+    "monad": {
+      "enabled": false,
+      "_chainComment": "Monad PGA L1. chainId + factory are PLACEHOLDERS — TODO verify on-chain.",
+      "chainId": 0,
+      "rpcEnv": "RESEARCH_RPC_MONAD",
+      "rpcFallbackEnv": "RESEARCH_RPC_MONAD_FALLBACK",
+      "wsEnv": "RESEARCH_WS_MONAD",
+      "multicall3": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "baseTokenSymbol": "WMON",
+      "baseTokenAddressTODO": "0x0000000000000000000000000000000000000000",
+      "factories": {
+        "_comment": "TODO: fill the actual V2-fork factory address + per-fork feeBps from chain docs.",
+        "V2Fork": { "address": "0x0000000000000000000000000000000000000000", "feeBps": 30 }
+      }
+    },
+
+    "hyperevm": {
+      "enabled": false,
+      "_chainComment": "HyperEVM PGA chain. chainId + factory are PLACEHOLDERS — TODO verify on-chain.",
+      "chainId": 0,
+      "rpcEnv": "RESEARCH_RPC_HYPEREVM",
+      "rpcFallbackEnv": "RESEARCH_RPC_HYPEREVM_FALLBACK",
+      "wsEnv": "RESEARCH_WS_HYPEREVM",
+      "multicall3": "0xcA11bde05977b3631167028862bE2a173976CA11",
+      "baseTokenSymbol": "WHYPE",
+      "baseTokenAddressTODO": "0x0000000000000000000000000000000000000000",
+      "factories": {
+        "_comment": "TODO: fill the actual V2-fork factory address + per-fork feeBps from chain docs.",
+        "V2Fork": { "address": "0x0000000000000000000000000000000000000000", "feeBps": 30 }
       }
     }
   }

--- a/research/freshPoolScanner.js
+++ b/research/freshPoolScanner.js
@@ -1,0 +1,294 @@
+'use strict';
+
+/**
+ * Stage 1b — FRESH-POOL scanner (PLAY #3): enumerate NEWLY-created V2-fork pairs by replaying
+ * `PairCreated` logs over a recent block window, keep only pools younger than an age budget,
+ * read their reserves, and emit the SAME snapshot shape scanner.js produces so pathfinder.js
+ * and backtester.js consume it unchanged.
+ *
+ * WHY (the long-tail / fresh-pool backrun edge):
+ * On a Priority-Gas-Auction chain (Monad / HyperEVM) the durable edge is NOT competing for
+ * the same fat blue-chip pools every searcher already watches — it's being first into a
+ * brand-new pool the moment liquidity lands, before the spread is arbitraged away. The
+ * freshness signal that makes this tractable is exactly the PairCreated log: it gives the
+ * creation block (hence the AGE) for free. We replay those logs, filter by age, snapshot
+ * reserves, and hand the result to the existing pipeline. Token safety (tokenSafety.js) then
+ * gates which of these fresh tokens we're actually willing to fire into — fresh pools are
+ * where honeypots live.
+ *
+ * SNAPSHOT SHAPE: identical to scanner.js (SNAPSHOT_VERSION pools[] with
+ * pair/factory/dex/token0/token1/reserve0/reserve1/feeBps) PLUS two extra per-pool fields the
+ * downstream stages ignore but the fresh-pool play uses:
+ *   - createdBlock: block the PairCreated log was emitted (freshness anchor).
+ *   - ageBlocks:    blockNumber(snapshot) - createdBlock (how fresh, in blocks).
+ *   - competitorCount: number of OTHER fresh pairs created in the same block on the same
+ *     factory (a crude contention proxy — many simultaneous launches => more bots watching).
+ * These are additive and optional, so a snapshot from freshPoolScanner is a strict superset of
+ * a scanner.js snapshot and drops into pathfinder/backtester with no changes.
+ *
+ * FIDELITY:
+ *  REAL: getLogs(PairCreated) over a block window + topic decode (ethers v6 Interface), age
+ *        filter, getReserves()/token0()/token1() reads, snapshot assembly. These are the real
+ *        live calls; with an RPC env var set this scanner runs against a real chain today.
+ *  TODO: getLogs RANGE CHUNKING for providers that cap block-span/result-count (we expose
+ *        `maxBlockSpan` and chunk, but very large backfills need cursoring + retry/backoff);
+ *        Multicall3 batching of the reserve reads; persistence to a real registry. Same TODO
+ *        surface as scanner.js — intentionally consistent.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { ethers } = require('ethers');
+
+const { loadConfig, enabledChains } = require('./config.js');
+const { SNAPSHOT_VERSION, makeProvider, readPair, readTokenMeta } = require('./scanner.js');
+
+// PairCreated(address indexed token0, address indexed token1, address pair, uint256 allPairsIdx)
+// This is the CANONICAL UniswapV2 factory event signature; PancakeSwap V2, SushiSwap V2 and the
+// vast majority of V2 forks emit the byte-identical event (same topic0), so this decode works
+// across them unchanged.
+// TODO(non-canonical forks): some forks rename/re-order args or add fields (e.g. a fee tier),
+// changing topic0 — those need a per-factory event signature/ABI override before getLogs.
+const PAIR_CREATED_ABI = [
+  'event PairCreated(address indexed token0, address indexed token1, address pair, uint256)'
+];
+const PAIR_CREATED_IFACE = new ethers.Interface(PAIR_CREATED_ABI);
+const PAIR_CREATED_TOPIC = ethers.id('PairCreated(address,address,address,uint256)');
+
+// Default fresh-pool knobs (overridable via config.freshScan). Documented constants:
+const DEFAULTS = Object.freeze({
+  // How many blocks back from `latest` to replay PairCreated for. A "fresh window".
+  lookbackBlocks: 5000,
+  // Maximum pool age (in blocks) to KEEP. Pools older than this are not "fresh" anymore and
+  // their launch spread is presumed already arbitraged. Must be <= lookbackBlocks to matter.
+  maxAgeBlocks: 1500,
+  // getLogs is chunked into spans of at most this many blocks (provider result/range caps).
+  maxBlockSpan: 2000,
+  // Cap on pools kept per factory, newest first, to bound downstream work.
+  maxFreshPerFactory: 500
+});
+
+/**
+ * Replay PairCreated logs for ONE factory over [fromBlock, toBlock], chunked by maxBlockSpan.
+ * Returns one record per created pair with its creation block.
+ *
+ * @param {ethers.Provider} provider
+ * @param {string} dex
+ * @param {{ address:string, feeBps:number }} factoryCfg
+ * @param {{ fromBlock:number, toBlock:number, maxBlockSpan:number }} window
+ * @returns {Promise<Array<{ pair:string, factory:string, dex:string, feeBps:number,
+ *           token0:string, token1:string, createdBlock:number }>>}
+ */
+async function replayPairCreated(provider, dex, factoryCfg, window) {
+  const factoryAddr = ethers.getAddress(factoryCfg.address);
+  const span = Math.max(1, Number(window.maxBlockSpan || DEFAULTS.maxBlockSpan));
+  const out = [];
+
+  for (let from = window.fromBlock; from <= window.toBlock; from += span) {
+    const to = Math.min(from + span - 1, window.toBlock);
+    let logs;
+    try {
+      logs = await provider.getLogs({
+        address: factoryAddr,
+        topics: [PAIR_CREATED_TOPIC],
+        fromBlock: from,
+        toBlock: to
+      });
+    } catch (err) {
+      // TODO(chunking): on "range too wide / too many results" providers, subdivide and retry
+      // with backoff. We warn and skip the chunk so a single bad span doesn't kill the scan.
+      console.warn(
+        `[freshScan] ${dex} getLogs ${from}-${to} failed: ${err.message}. ` +
+          'TODO: subdivide+retry. Skipping this span.'
+      );
+      continue;
+    }
+    for (const log of logs) {
+      let parsed;
+      try {
+        parsed = PAIR_CREATED_IFACE.parseLog({ topics: log.topics, data: log.data });
+      } catch (_err) {
+        continue; // not a PairCreated we can decode
+      }
+      out.push({
+        pair: ethers.getAddress(parsed.args.pair),
+        factory: factoryAddr,
+        dex,
+        feeBps: Number(factoryCfg.feeBps),
+        token0: ethers.getAddress(parsed.args.token0),
+        token1: ethers.getAddress(parsed.args.token1),
+        createdBlock: Number(log.blockNumber)
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Annotate a list of created-pair records with competitorCount = how many OTHER pairs were
+ * created in the SAME block on the SAME factory (a crude same-block-launch contention proxy).
+ * Pure helper (no I/O) so it's testable.
+ *
+ * @param {Array<{createdBlock:number, pair:string}>} created
+ * @returns {Map<string, number>} pair -> competitorCount
+ */
+function computeCompetitorCounts(created) {
+  const perBlock = new Map();
+  for (const c of created) {
+    perBlock.set(c.createdBlock, (perBlock.get(c.createdBlock) || 0) + 1);
+  }
+  const out = new Map();
+  for (const c of created) {
+    // "competitors" = others in the same block => total in block minus self.
+    out.set(c.pair, (perBlock.get(c.createdBlock) || 1) - 1);
+  }
+  return out;
+}
+
+/**
+ * Filter created pairs to those younger than maxAgeBlocks at `headBlock`, newest first,
+ * capped at maxFreshPerFactory. Pure helper (testable).
+ *
+ * @param {Array<{createdBlock:number}>} created
+ * @param {number} headBlock
+ * @param {{ maxAgeBlocks:number, maxFreshPerFactory:number }} cfg
+ * @returns {Array<object>} filtered + age-annotated records (adds ageBlocks).
+ */
+function filterFresh(created, headBlock, cfg) {
+  const maxAge = Number(cfg.maxAgeBlocks ?? DEFAULTS.maxAgeBlocks);
+  const cap = Number(cfg.maxFreshPerFactory ?? DEFAULTS.maxFreshPerFactory);
+  const withAge = created
+    .map((c) => ({ ...c, ageBlocks: headBlock - c.createdBlock }))
+    .filter((c) => c.ageBlocks >= 0 && c.ageBlocks <= maxAge)
+    .sort((a, b) => b.createdBlock - a.createdBlock); // newest first
+  return withAge.slice(0, cap);
+}
+
+/**
+ * Scan ONE chain for fresh pools and assemble a (superset) snapshot. Does not write to disk.
+ * @param {object} chain - element from enabledChains().
+ * @param {object} config - full research config (uses .freshScan).
+ * @returns {Promise<object|null>} snapshot or null if skipped.
+ */
+async function scanFreshChain(chain, config) {
+  const provider = makeProvider(chain);
+  if (!provider) return null;
+
+  const cfg = { ...DEFAULTS, ...(config.freshScan || {}) };
+  const head = await provider.getBlockNumber();
+  const fromBlock = Math.max(0, head - Number(cfg.lookbackBlocks || DEFAULTS.lookbackBlocks));
+
+  const pools = [];
+  const factories = chain.cfg.factories || {};
+  for (const [dex, factoryCfg] of Object.entries(factories)) {
+    if (dex.startsWith('_')) continue;
+    const created = await replayPairCreated(provider, dex, factoryCfg, {
+      fromBlock,
+      toBlock: head,
+      maxBlockSpan: cfg.maxBlockSpan
+    });
+    const competitorCounts = computeCompetitorCounts(created);
+    const fresh = filterFresh(created, head, cfg);
+    console.log(
+      `[freshScan] ${chain.key}/${dex}: ${created.length} created in last ` +
+        `${head - fromBlock} blocks, ${fresh.length} fresh (<= ${cfg.maxAgeBlocks} blocks old).`
+    );
+
+    for (const f of fresh) {
+      try {
+        const rec = await readPair(provider, f.pair, f.feeBps, { factory: f.factory, dex: f.dex });
+        // Attach freshness + contention metadata (additive; downstream ignores unknown keys).
+        rec.createdBlock = f.createdBlock;
+        rec.ageBlocks = f.ageBlocks;
+        rec.competitorCount = competitorCounts.get(f.pair) || 0;
+        pools.push(rec);
+      } catch (err) {
+        console.warn(`[freshScan] failed reading fresh pair ${f.pair} on ${dex}: ${err.message}`);
+      }
+    }
+  }
+
+  const tokenAddrs = new Set();
+  for (const p of pools) {
+    tokenAddrs.add(p.token0);
+    tokenAddrs.add(p.token1);
+  }
+  const tokens = await readTokenMeta(provider, tokenAddrs);
+
+  return {
+    version: SNAPSHOT_VERSION,
+    chainKey: chain.key,
+    chainId: chain.cfg.chainId,
+    blockNumber: head,
+    baseToken: chain.baseToken.address,
+    baseTokenSymbol: chain.baseToken.symbol,
+    takenAtIso: new Date().toISOString(),
+    // Provenance marker so a fresh-pool snapshot is distinguishable from a full scanner.js one.
+    snapshotKind: 'fresh',
+    freshScan: { lookbackBlocks: cfg.lookbackBlocks, maxAgeBlocks: cfg.maxAgeBlocks, fromBlock, headBlock: head },
+    tokens,
+    pools
+  };
+}
+
+/**
+ * Write a snapshot to disk (creates parent dirs). Returns the path written.
+ * @param {object} snapshot
+ * @param {string} outPath
+ * @returns {string}
+ */
+function writeSnapshot(snapshot, outPath) {
+  const abs = path.isAbsolute(outPath) ? outPath : path.join(process.cwd(), outPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(snapshot, null, 2));
+  return abs;
+}
+
+/**
+ * CLI entrypoint: scan all enabled chains for fresh pools, one snapshot per chain.
+ */
+async function main() {
+  const { config, sourcePath } = loadConfig();
+  console.log(`[freshScan] config: ${sourcePath}`);
+  const chains = enabledChains(config);
+  if (chains.length === 0) {
+    console.warn('[freshScan] no enabled chains. Enable one in research/config.json.');
+    return;
+  }
+
+  for (const chain of chains) {
+    console.log(`[freshScan] scanning ${chain.key} (chainId ${chain.cfg.chainId}) for fresh pools...`);
+    const snapshot = await scanFreshChain(chain, config);
+    if (!snapshot) continue;
+
+    const base =
+      (config.freshScan && config.freshScan.snapshotOutPath) ||
+      (config.scan && config.scan.snapshotOutPath) ||
+      'research/data/snapshot.json';
+    const ext = path.extname(base);
+    // Canonical fresh filename: snapshot.<chain>.fresh.json (distinct from the full scan).
+    const outPath = `${base.slice(0, base.length - ext.length)}.${chain.key}.fresh${ext}`;
+    const written = writeSnapshot(snapshot, outPath);
+    console.log(
+      `[freshScan] ${chain.key}: ${snapshot.pools.length} fresh pools @ block ${snapshot.blockNumber} -> ${written}`
+    );
+  }
+}
+
+module.exports = {
+  DEFAULTS,
+  PAIR_CREATED_ABI,
+  PAIR_CREATED_TOPIC,
+  replayPairCreated,
+  computeCompetitorCounts,
+  filterFresh,
+  scanFreshChain,
+  writeSnapshot
+};
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[freshScan] fatal:', err);
+    process.exitCode = 1;
+  });
+}

--- a/research/gasBidPolicy.js
+++ b/research/gasBidPolicy.js
@@ -1,0 +1,187 @@
+'use strict';
+
+/**
+ * Dynamic gas-bid policy for PRIORITY-GAS-AUCTION (PGA) chains — PLAY #3.
+ *
+ * CONTEXT (from the 2026 MEV-viability research):
+ * On a PGA chain like Monad or HyperEVM there is NO sealed-bid OFA / private orderflow to
+ * plug into; inclusion priority is bought openly with the priority fee (the "gas bid"). The
+ * fastest bot that bids the highest effective gas price for a given block lands the backrun.
+ * This is the classic ETH-mainnet-2020 Priority Gas Auction, re-homed onto a cheap, fast,
+ * under-contested L1/L2. The whole edge for fresh-pool backruns (freshPoolScanner.js) is
+ * landing the tx — and that is a BIDDING problem, not a math problem.
+ *
+ * THE POLICY (pure, deterministic, testable):
+ * We bid "just enough to win" rather than the naive "all of it":
+ *   1. Never bid so much that the op turns unprofitable: bid ≤ maxBidFraction × expectedProfit.
+ *   2. Bid just ABOVE the marginal competitor's observed bid (outbid by a small increment) when
+ *      we have a competitor signal — winning by a hair maximises retained profit.
+ *   3. Floor at the chain's base/priority fee so the tx is at least includable.
+ *   4. Cap the *effective* gas price so a single op can never bleed more than the configured
+ *      fraction of its own expected profit into the bid (defence vs. an irrational rival who
+ *      bids to zero-EV — we walk away instead, see `shouldBid`).
+ *
+ * All inputs/outputs are plain numbers (gwei / USD), no bigint, no I/O — so this file is a
+ * unit-test target. Wiring it to a live mempool competitor feed is a documented TODO.
+ *
+ * RELATIONSHIP TO gasModel.js: gasModel prices what a cycle COSTS in gas at a given gas price.
+ * THIS file decides what gas price to BID. The backtester uses gasModel for cost accounting
+ * and can use this policy to stress-test "what tip do we need, and is the op still GO after we
+ * pay to win the auction?".
+ */
+
+// Documented policy constants. All overridable via config.gasBid.
+const DEFAULTS = Object.freeze({
+  // Hard ceiling: the priority bid may consume at most this fraction of expected gross profit.
+  // 0.5 => we never give up more than half the edge to the auction. Above this we'd rather not
+  // play (a rational searcher keeps positive EV; bidding past here is how PGAs go to zero-EV).
+  maxBidFraction: 0.5,
+  // When outbidding a known competitor, exceed them by this fraction (1.05 => +5%). Small, so
+  // we win by a hair and keep the rest of the edge.
+  outbidIncrement: 1.05,
+  // Absolute minimum increment over a competitor (in gwei) when the fractional bump rounds to
+  // ~0 on a tiny competitor bid — guarantees a strict outbid the sequencer will honour.
+  minOutbidGwei: 0.01,
+  // Assumed gas units per op when converting a USD profit budget into a gwei bid ceiling.
+  // Should match the executor profile in gasModel.js you intend to ship (lean target by
+  // default). Documented, overridable; the backtester passes the real hop-derived figure.
+  assumedGasUnits: 150000,
+  // Floor: never bid below this many gwei of priority (chain-dependent inclusion minimum).
+  minPriorityGwei: 0.0,
+  // Safety ceiling on the absolute bid regardless of profit, to avoid fat-finger blowups.
+  absMaxPriorityGwei: 5000.0
+});
+
+/**
+ * Convert a USD profit budget into the maximum priority-fee (gwei) we could pay while keeping
+ * the op break-even, given gas units and the native-token USD price.
+ *
+ *   maxTipUsd            = profitUsd × maxBidFraction
+ *   maxTipNativePerGas   = maxTipUsd / nativeUsdPrice / gasUnits     (native per gas unit)
+ *   maxTipGwei           = maxTipNativePerGas × 1e9
+ *
+ * @param {number} expectedProfitUsd - gross expected profit of the op (before the tip).
+ * @param {object} ctx - { nativeUsdPrice, gasUnits, maxBidFraction }.
+ * @returns {number} ceiling in gwei (>= 0).
+ */
+function profitToMaxBidGwei(expectedProfitUsd, ctx) {
+  const nativeUsd = Number(ctx.nativeUsdPrice || 0);
+  const gasUnits = Number(ctx.gasUnits || DEFAULTS.assumedGasUnits);
+  const frac = Number(ctx.maxBidFraction ?? DEFAULTS.maxBidFraction);
+  if (nativeUsd <= 0 || gasUnits <= 0 || expectedProfitUsd <= 0) return 0;
+  const maxTipUsd = expectedProfitUsd * frac;
+  const maxTipNative = maxTipUsd / nativeUsd; // total native we can spend on the tip
+  const maxTipNativePerGas = maxTipNative / gasUnits;
+  return maxTipNativePerGas * 1e9; // -> gwei
+}
+
+/**
+ * Decide whether an op is worth bidding on at all, given the current competitor bid.
+ * If beating the competitor (by our increment) would exceed our profit-derived ceiling, the
+ * auction has bid the EV away — we DECLINE (return false) rather than win unprofitably.
+ *
+ * @param {object} args
+ * @param {number} args.expectedProfitUsd
+ * @param {number} [args.competitorBidGwei=0]
+ * @param {number} [args.nativeUsdPrice] - runtime native-token USD price (for the ceiling).
+ * @param {number} [args.gasUnits] - op gas units (defaults to cfg.assumedGasUnits).
+ * @param {object} [cfg]
+ * @returns {{ shouldBid:boolean, ceilingGwei:number, requiredToWinGwei:number, reason:string }}
+ */
+function shouldBid(args, cfg = {}) {
+  const c = { ...DEFAULTS, ...(cfg || {}) };
+  // The profit->bid ceiling needs the RUNTIME market context (native USD price + gas units),
+  // which travel on `args`, not on the policy cfg. Merge them so the ceiling is computed from
+  // live numbers and falls back to documented defaults only when a field is omitted.
+  const ctx = {
+    nativeUsdPrice: args.nativeUsdPrice,
+    gasUnits: args.gasUnits ?? c.assumedGasUnits,
+    maxBidFraction: c.maxBidFraction
+  };
+  const ceiling = profitToMaxBidGwei(args.expectedProfitUsd, ctx);
+  const competitor = Math.max(0, Number(args.competitorBidGwei || 0));
+  const requiredToWin = competitor > 0
+    ? Math.max(competitor * c.outbidIncrement, competitor + c.minOutbidGwei)
+    : Math.max(c.minPriorityGwei, 0);
+
+  if (args.expectedProfitUsd <= 0) {
+    return { shouldBid: false, ceilingGwei: ceiling, requiredToWinGwei: requiredToWin, reason: 'non-positive expected profit' };
+  }
+  if (requiredToWin > ceiling) {
+    return {
+      shouldBid: false,
+      ceilingGwei: ceiling,
+      requiredToWinGwei: requiredToWin,
+      reason: `auction bid-away: need ${requiredToWin.toFixed(4)} gwei to win > ${ceiling.toFixed(4)} gwei ceiling`
+    };
+  }
+  return { shouldBid: true, ceilingGwei: ceiling, requiredToWinGwei: requiredToWin, reason: 'positive-EV win available' };
+}
+
+/**
+ * Compute the actual priority-fee (gwei) to submit for an op on a PGA chain.
+ *
+ * Logic:
+ *   - If we have a competitor signal: bid just above them (outbidIncrement / minOutbidGwei),
+ *     but never above the profit ceiling and never below the chain floor.
+ *   - If we have NO competitor signal: bid the chain floor (minPriorityGwei) — there's no one
+ *     to outbid, so paying more is pure waste. (We can still land first by latency.)
+ *   - Always clamp to [minPriorityGwei, min(ceiling, absMaxPriorityGwei)].
+ *
+ * @param {object} args
+ * @param {number} args.expectedProfitUsd
+ * @param {number} [args.competitorBidGwei] - observed marginal competitor priority fee (gwei).
+ * @param {number} [args.nativeUsdPrice] - runtime native-token USD price (for the ceiling).
+ * @param {number} [args.gasUnits] - op gas units (defaults to cfg.assumedGasUnits).
+ * @param {number} [args.baseFeeGwei=0] - chain base fee (informational; bid is the *priority* tip).
+ * @param {object} [cfg] - config.gasBid overrides.
+ * @returns {{
+ *   bidGwei:number, ceilingGwei:number, floorGwei:number,
+ *   outbid:boolean, clampedToCeiling:boolean, decision:object
+ * }}
+ */
+function computeBid(args, cfg = {}) {
+  const c = { ...DEFAULTS, ...(cfg || {}) };
+  const decision = shouldBid(args, c);
+  const ceiling = Math.min(decision.ceilingGwei, c.absMaxPriorityGwei);
+  const floor = Math.max(0, Number(c.minPriorityGwei || 0));
+
+  if (!decision.shouldBid) {
+    // Declining: return the floor as a non-binding suggestion but mark it unprofitable to win.
+    return {
+      bidGwei: floor,
+      ceilingGwei: ceiling,
+      floorGwei: floor,
+      outbid: false,
+      clampedToCeiling: false,
+      decision
+    };
+  }
+
+  const hasCompetitor = Number(args.competitorBidGwei || 0) > 0;
+  let target = hasCompetitor ? decision.requiredToWinGwei : floor;
+
+  // Clamp into [floor, ceiling].
+  let clampedToCeiling = false;
+  if (target > ceiling) {
+    target = ceiling;
+    clampedToCeiling = true;
+  }
+  if (target < floor) target = floor;
+
+  return {
+    bidGwei: target,
+    ceilingGwei: ceiling,
+    floorGwei: floor,
+    outbid: hasCompetitor && !clampedToCeiling,
+    clampedToCeiling,
+    decision
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  profitToMaxBidGwei,
+  shouldBid,
+  computeBid
+};

--- a/research/run.js
+++ b/research/run.js
@@ -58,32 +58,33 @@ function loadSnapshot(arg) {
   return JSON.parse(fs.readFileSync(abs, 'utf8'));
 }
 
-function main() {
+async function main() {
   const arg = process.argv[2];
   const { config } = loadConfig();
   const snapshot = loadSnapshot(arg);
 
+  const kind = snapshot.snapshotKind === 'fresh' ? ' [FRESH-POOL]' : '';
   console.log(
     `[run] snapshot chain=${snapshot.chainKey} block=${snapshot.blockNumber} ` +
-      `pools=${(snapshot.pools || []).length} base=${snapshot.baseToken}`
+      `pools=${(snapshot.pools || []).length} base=${snapshot.baseToken}${kind}`
   );
 
   const candidates = findCandidateCycles(snapshot, config.pathfinder || {});
   console.log(`[run] candidate cycles: ${candidates.length}`);
 
   // obs left mostly empty on purpose: win-rate falls back to config, revert-rate is
-  // unmeasured (forces a provisional verdict + the revm TODO warning).
-  const result = runBacktest(snapshot, candidates, config, { windowDays: 1 });
+  // unmeasured (forces a provisional verdict + the revm TODO warning). The token-safety GATE
+  // runs offline here (no provider) → pass-through unless an injectedSafety map is provided;
+  // it becomes a hard gate the moment a provider/router is wired (see backtester.runBacktest).
+  const result = await runBacktest(snapshot, candidates, config, { windowDays: 1 });
   printReport(result);
 }
 
 if (require.main === module) {
-  try {
-    main();
-  } catch (err) {
+  main().catch((err) => {
     console.error('[run] fatal:', err.message);
     process.exitCode = 1;
-  }
+  });
 }
 
 module.exports = { demoSnapshot };

--- a/research/sizing.js
+++ b/research/sizing.js
@@ -1,0 +1,242 @@
+'use strict';
+
+/**
+ * Liquidity-capped CPMM optimal-input sizing (PLAY #3).
+ *
+ * The backtester's original `optimalInput` capped the search at the FIRST hop's base-side
+ * reserve and grid+ternary-searched gross profit. That is fine for fat blue-chip pools, but
+ * for the fresh-pool / long-tail play it is dangerous: a brand-new pool may hold only a few
+ * units of base liquidity, so the "optimum" can demand a trade that:
+ *   (a) exceeds what the THINNEST hop along the cycle can absorb (not just the first hop), and
+ *   (b) blows a huge price-impact crater that a CPMM-only profit number happily ignores but a
+ *       real fill (and the next searcher) will not.
+ *
+ * This module sizes against TWO hard caps and one budget, all derived from the actual cycle:
+ *   1. RESERVE CAP — input ≤ reserveCapFraction × min base-equivalent reserve across the cycle
+ *      (the cycle can never route more than its thinnest pool holds).
+ *   2. PRICE-IMPACT BUDGET — input ≤ the largest size whose cumulative cycle price impact
+ *      stays under maxPriceImpactBps. Impact is measured as 1 - (realised rate / marginal
+ *      rate) over the whole round-trip, which is the size-dependent slippage the trade self-
+ *      inflicts. This is the cap that protects against fresh-pool craters.
+ *   3. Within the capped interval, find the gross-profit-maximising input by the same unimodal
+ *      (grid + ternary) search, since Profit(x) is unimodal for a CPMM cycle.
+ *
+ * Pure functions over the hop list (reserveIn/reserveOut/feeBps) + a snapshot of policy knobs.
+ * No I/O. Fully testable offline. The backtester calls `optimalInputCapped` instead of any
+ * naive sizing.
+ *
+ * NOTE on closed form: for a single 2-pool cycle there is a closed-form optimum
+ *   x* = (sqrt(Ra*Rb*ka*kb) - Ra) / (something)  — exact but algebra-heavy and brittle to
+ * extend past 2 hops / mixed fees. We keep the robust unimodal SEARCH (correct for n hops and
+ * arbitrary fees) and add the two hard CAPS, which is what actually matters for the fresh-pool
+ * play. A true closed form for the ≤5-hop case is a noted TODO upgrade, not a correctness gap.
+ */
+
+const { getAmountOut } = require('./pathfinder.js');
+
+const DEFAULTS = Object.freeze({
+  // Never route more than this fraction of the thinnest pool's base-equivalent reserve.
+  reserveCapFraction: 0.3,
+  // Cumulative round-trip price-impact budget, in basis points. 300 = 3%. Beyond this the
+  // trade craters the pool and the edge is illusory (and a competitor front-runs the rest).
+  maxPriceImpactBps: 300,
+  // Grid resolution for the capped search (log-spaced), then a ternary refine.
+  gridSteps: 80
+});
+
+/**
+ * Round-trip output for an input over the cycle's hops (CPMM, fee-inclusive).
+ * @param {bigint} amountIn
+ * @param {Array<{reserveIn:string|bigint, reserveOut:string|bigint, feeBps:number}>} hops
+ * @returns {bigint} final base-token out.
+ */
+function cycleOut(amountIn, hops) {
+  let amt = amountIn;
+  for (const h of hops) {
+    amt = getAmountOut(amt, BigInt(h.reserveIn), BigInt(h.reserveOut), h.feeBps);
+    if (amt <= 0n) return 0n;
+  }
+  return amt;
+}
+
+/**
+ * Marginal (size→0) round-trip rate of the cycle as a float: product of fee-adjusted
+ * per-hop marginal rates. Used as the impact baseline (the rate at infinitesimal size).
+ * @param {Array<object>} hops
+ * @returns {number} out-per-in at zero size (>1 means the cycle is marginally profitable).
+ */
+function marginalCycleRate(hops) {
+  let rate = 1;
+  for (const h of hops) {
+    const rin = Number(BigInt(h.reserveIn));
+    const rout = Number(BigInt(h.reserveOut));
+    if (rin <= 0 || rout <= 0) return 0;
+    const feeFactor = (10000 - h.feeBps) / 10000;
+    rate *= feeFactor * (rout / rin);
+  }
+  return rate;
+}
+
+/**
+ * Realised round-trip rate at a given size (out/in as a float).
+ * @param {bigint} amountIn
+ * @param {Array<object>} hops
+ * @returns {number}
+ */
+function realisedRate(amountIn, hops) {
+  if (amountIn <= 0n) return 0;
+  const out = cycleOut(amountIn, hops);
+  return Number(out) / Number(amountIn);
+}
+
+/**
+ * Cumulative round-trip price impact at a given size, in basis points:
+ *   impact = 1 - realisedRate / marginalRate.
+ * (Marginal rate is the best-case zero-size rate; realised degrades with size.)
+ * @param {bigint} amountIn
+ * @param {Array<object>} hops
+ * @returns {number} impact in bps (>= 0).
+ */
+function priceImpactBps(amountIn, hops) {
+  const marg = marginalCycleRate(hops);
+  if (marg <= 0) return Infinity;
+  const real = realisedRate(amountIn, hops);
+  const impact = 1 - real / marg;
+  return Math.max(0, impact) * 10000;
+}
+
+/**
+ * The base-equivalent input cap from reserves: the thinnest "input-side" reserve along the
+ * cycle, scaled by reserveCapFraction. We take the minimum reserveIn across hops as a
+ * conservative proxy for the cycle's absorptive capacity (a hop can't take more base-
+ * equivalent than its input reserve without catastrophic impact).
+ * @param {Array<object>} hops
+ * @param {number} reserveCapFraction
+ * @returns {bigint}
+ */
+function reserveCap(hops, reserveCapFraction) {
+  let minReserveIn = null;
+  for (const h of hops) {
+    const r = BigInt(h.reserveIn);
+    if (minReserveIn === null || r < minReserveIn) minReserveIn = r;
+  }
+  if (minReserveIn === null || minReserveIn <= 0n) return 0n;
+  // Scale by fraction using bigint math (fraction in [0,1] -> per-10000 to stay integer).
+  const fracBps = BigInt(Math.max(0, Math.round(reserveCapFraction * 10000)));
+  return (minReserveIn * fracBps) / 10000n;
+}
+
+/**
+ * Largest input whose cumulative round-trip impact stays within maxPriceImpactBps, found by
+ * bisection on the (monotonically increasing) impact-vs-size curve, clamped to `hardCap`.
+ * If even the hardCap is within budget, returns hardCap.
+ * @param {Array<object>} hops
+ * @param {bigint} hardCap
+ * @param {number} maxImpactBps
+ * @returns {bigint}
+ */
+function impactCappedInput(hops, hardCap, maxImpactBps) {
+  if (hardCap <= 0n) return 0n;
+  if (priceImpactBps(hardCap, hops) <= maxImpactBps) return hardCap;
+  let lo = 0n;
+  let hi = hardCap;
+  // Bisection: impact(x) is monotonic increasing in x for a CPMM cycle.
+  for (let i = 0; i < 256 && hi - lo > 1n; i++) {
+    const mid = (lo + hi) / 2n;
+    if (priceImpactBps(mid, hops) <= maxImpactBps) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+/**
+ * The liquidity-capped optimal-input sizer. Replaces naive sizing in the backtester.
+ *
+ * @param {Array<{reserveIn:string|bigint, reserveOut:string|bigint, feeBps:number}>} hops
+ * @param {object} [cfg] - { reserveCapFraction, maxPriceImpactBps, gridSteps }.
+ * @returns {{
+ *   amountIn:bigint, amountOut:bigint, grossProfitWei:bigint,
+ *   reserveCapWei:bigint, impactCapWei:bigint, hardCapWei:bigint,
+ *   priceImpactBps:number, boundBy:'reserve'|'impact'|'interior'
+ * }}
+ */
+function optimalInputCapped(hops, cfg = {}) {
+  const c = { ...DEFAULTS, ...(cfg || {}) };
+  const empty = {
+    amountIn: 0n, amountOut: 0n, grossProfitWei: 0n,
+    reserveCapWei: 0n, impactCapWei: 0n, hardCapWei: 0n,
+    priceImpactBps: 0, boundBy: 'interior'
+  };
+  if (!hops || hops.length === 0) return empty;
+
+  const rCap = reserveCap(hops, c.reserveCapFraction);
+  if (rCap <= 0n) return empty;
+  const iCap = impactCappedInput(hops, rCap, c.maxPriceImpactBps);
+  const hardCap = iCap > 0n ? iCap : rCap;
+  if (hardCap <= 0n) return { ...empty, reserveCapWei: rCap };
+
+  const profitAt = (x) => {
+    if (x <= 0n) return -1n;
+    return cycleOut(x, hops) - x;
+  };
+
+  // Log-spaced grid over [lo, hardCap] then ternary refine (Profit is unimodal).
+  const lo = hardCap / 100000000n > 0n ? hardCap / 100000000n : 1n;
+  const steps = Math.max(8, Number(c.gridSteps || DEFAULTS.gridSteps));
+  const loF = Number(lo);
+  const ratio = Number(hardCap) / loF;
+  let best = { amountIn: lo, profit: profitAt(lo) };
+  for (let i = 1; i <= steps; i++) {
+    const xF = loF * Math.pow(ratio, i / steps);
+    const x = BigInt(Math.max(1, Math.round(xF)));
+    const p = profitAt(x);
+    if (p > best.profit) best = { amountIn: x, profit: p };
+  }
+  let left = best.amountIn / 4n > 0n ? best.amountIn / 4n : 1n;
+  let right = best.amountIn * 4n < hardCap ? best.amountIn * 4n : hardCap;
+  for (let iter = 0; iter < 200 && right - left > 1n; iter++) {
+    const third = (right - left) / 3n;
+    const m1 = left + third;
+    const m2 = right - third;
+    if (profitAt(m1) < profitAt(m2)) left = m1 + 1n;
+    else right = m2;
+  }
+  const candidatesX = [best.amountIn, left, right];
+  let xStar = candidatesX[0];
+  let pStar = profitAt(xStar);
+  for (const x of candidatesX.slice(1)) {
+    const p = profitAt(x);
+    if (p > pStar) { pStar = p; xStar = x; }
+  }
+
+  const outStar = cycleOut(xStar, hops);
+  // Classify which constraint bound the result (for transparency in the report).
+  let boundBy = 'interior';
+  if (xStar >= hardCap - (hardCap / 1000n + 1n)) {
+    boundBy = iCap < rCap ? 'impact' : 'reserve';
+  }
+  return {
+    amountIn: xStar,
+    amountOut: outStar,
+    grossProfitWei: outStar - xStar,
+    reserveCapWei: rCap,
+    impactCapWei: iCap,
+    hardCapWei: hardCap,
+    priceImpactBps: priceImpactBps(xStar, hops),
+    boundBy
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  cycleOut,
+  marginalCycleRate,
+  realisedRate,
+  priceImpactBps,
+  reserveCap,
+  impactCappedInput,
+  optimalInputCapped
+};

--- a/research/tokenSafety.js
+++ b/research/tokenSafety.js
@@ -1,0 +1,468 @@
+'use strict';
+
+/**
+ * Token-safety guard (PLAY #4) — a PER-TOKEN base<->token buy-then-sell probe that flags
+ * unsellable / fee-on-transfer / transfer-tax / max-tx-limited / honeypot tokens BEFORE
+ * any candidate cycle is allowed to fire.
+ *
+ * SCOPE / UNIT OF MEASUREMENT (read this first — it was previously overstated):
+ * The probe measures ONE token at a time via a 2-hop base<->token round-trip:
+ *   base --> token --> base. It is NOT a whole-cycle measurement, and a single 2-hop probe
+ * must NEVER be presented as the round-trip tax of a longer (3–5 hop) candidate cycle — that
+ * would be apples-to-oranges (the interior token-to-token hops of a cycle are different pools
+ * with their own fees/impact). To make a multi-hop candidate safe, the gate runs THIS 2-hop
+ * probe INDEPENDENTLY for EACH distinct non-base token on the path and drops the candidate if
+ * ANY one token reverts on sell or taxes above threshold. See backtester.gateTokenSafety.
+ *
+ * WHY THIS IS THE HIGHEST-PRIORITY GUARD (it enables PLAY #3):
+ * The long-tail / fresh-pool backrun edge (freshPoolScanner.js) lives in brand-new V2-fork
+ * pools whose tokens are overwhelmingly malicious: honeypots that let you BUY but block the
+ * SELL, fee-on-transfer tokens that silently skim 10-99% on transfer, tokens with a
+ * post-launch `setFee()` flip, and per-tx maximums that make your sized trade revert. A pure
+ * CPMM backtest (pathfinder + backtester) is BLIND to all of these — it assumes the V2 pair
+ * math is the whole story. Firing into one of these tokens is a 100% capital loss on that leg
+ * even though the math said "profit". So every non-base token on a candidate MUST pass this
+ * per-token probe first.
+ *
+ * WHAT THE PER-TOKEN PROBE PROVES (the base<->token round-trip invariant):
+ *   buy  baseToken --(base<->token pool)-->  token       (amountToken_received)
+ *   sell token     --(base<->token pool)-->  baseToken   (amountBase_back)
+ * A clean (taxless, sellable) token returns amountBase_back ≈ amountIn minus only the two
+ * V2 swap fees + price impact. We compute the EXPECTED clean base<->token round-trip with the
+ * same CPMM math the backtester uses (baseline must be the SAME base<->token pool we quote, or
+ * the tax number is meaningless), then compare it to what the chain actually returns when we
+ * eth_call the real router with getAmountsOut([base,token]) and getAmountsOut([token,base]).
+ * The shortfall, net of the fees we already accounted for, is the MEASURED transfer/sell tax.
+ * A revert on the SELL leg (with a non-trivial BUY) is the honeypot signature — and that
+ * revert signal needs NO baseline, so it gates EVERY non-base token, interior or not.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────────────────
+ * FIDELITY — what is REAL here vs what is TODO'd (be honest):
+ *
+ *  REAL (implemented):
+ *   - The eth_call structure to read getAmountsOut on a real V2 router for the base<->token
+ *     2-hop probe (the standard way to ask "what would this swap return", fee-on-transfer-
+ *     INCLUSIVE when the router/token apply the tax inside transfer), and a direct
+ *     pair.getReserves() cross-check.
+ *   - The clean-CPMM expected base<->token round-trip (pure, offline, testable) used as the
+ *     baseline — apples-to-apples with the same base<->token venue we quote.
+ *   - The decision logic: classify {safe, reasons[], measuredSellTax} from real-vs-expected,
+ *     plus a revert => honeypot rule and a max-tx probe (two sizes diverge non-monotonically).
+ *
+ *  TODO (needs a forked EVM — anvil/foundry/revm — to be exact):
+ *   - A TRUE buy-then-sell where we (a) fund a throwaway EOA with baseToken via state
+ *     override, (b) actually execute the buy so we hold the token, then (c) actually execute
+ *     the sell from that holding. getAmountsOut is an APPROXIMATION: many honeypots gate on
+ *     `tx.origin`/holder state/whitelist and look fine to a stateless getAmountsOut but revert
+ *     on a real holder's sell. Only a forked execution catches those. We expose simulateOnFork
+ *     as the seam and clearly mark it unimplemented when no fork URL is provided.
+ *   - Post-launch FEE-FLIP detection beyond a single snapshot needs replaying the token's
+ *     setFee/owner calls or watching a holding period; we flag the *capability* (owner can
+ *     mutate fees) heuristically and TODO the temporal check.
+ *
+ * The exported interface is stable regardless of fidelity level:
+ *     checkToken(...) -> { safe:boolean, reasons:string[], measuredSellTax:number, ... }
+ * so the backtester can gate on it today and the fork upgrade is drop-in later.
+ * ─────────────────────────────────────────────────────────────────────────────────────────
+ */
+
+const { ethers } = require('ethers');
+const { getAmountOut } = require('./pathfinder.js');
+
+// Standard UniswapV2-style router read methods. getAmountsOut is the canonical "quote"
+// call; swapExactTokensForTokensSupportingFeeOnTransferTokens is the fee-on-transfer-aware
+// swap whose existence we rely on conceptually (the real execution path lives on a fork).
+const ROUTER_ABI = [
+  'function getAmountsOut(uint256 amountIn, address[] path) view returns (uint256[] amounts)'
+];
+
+const PAIR_ABI = [
+  'function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)',
+  'function token0() view returns (address)',
+  'function token1() view returns (address)'
+];
+
+// Heuristic ownership/mutable-fee probe ABI (best-effort; absence is non-fatal).
+const TOKEN_PROBE_ABI = [
+  'function owner() view returns (address)',
+  'function getOwner() view returns (address)'
+];
+
+// Default policy knobs. All overridable via config.tokenSafety. Documented constants:
+const DEFAULTS = Object.freeze({
+  // A round-trip whose measured tax exceeds this (fraction, e.g. 0.10 = 10%) is unsafe.
+  // Fresh-pool launches legitimately carry a small buy/sell tax (1-5%); >10% net is a
+  // value-extraction trap that almost always erases an arb edge.
+  maxSellTax: 0.10,
+  // Probe size as a fraction of the SELL-pool's token-side reserve. Small enough to keep
+  // price impact low (so impact doesn't masquerade as tax) but non-dust so per-tx minimums
+  // and rounding-skim taxes actually trigger. 0.1% of reserves.
+  probeReserveFraction: 0.001,
+  // Second, larger probe (×N) used for the max-tx / non-monotonic-tax detector. If the tax
+  // measured at the larger size jumps far beyond what price impact explains, the token has a
+  // size-dependent gate (max-tx limit or graduated tax).
+  largeProbeMultiplier: 25,
+  // Tolerance (fraction) for treating two tax measurements as "the same". Above this gap the
+  // tax is size-dependent → suspicious.
+  taxConsistencyTolerance: 0.03,
+  // If true, an inability to even quote the sell (revert/empty) is treated as a honeypot.
+  treatSellQuoteFailureAsHoneypot: true
+});
+
+/**
+ * Compute the EXPECTED clean (taxless) base<->token round-trip output using the same CPMM math
+ * the backtester trusts. This is the baseline we compare the real chain against; the gap is
+ * tax. For the comparison to be apples-to-apples, BOTH buyPool and sellPool must describe the
+ * SAME base<->token venue the live quote uses (i.e. base->token and token->base over the
+ * token's direct base pool) — NOT two different interior hops of a longer cycle.
+ *
+ * @param {bigint} amountIn - base-token in (wei).
+ * @param {{reserveBase:bigint, reserveToken:bigint, feeBps:number}} buyPool  - base->token leg.
+ * @param {{reserveToken:bigint, reserveBase:bigint, feeBps:number}} sellPool - token->base leg.
+ * @returns {{ tokenMid: bigint, baseBack: bigint }}
+ */
+function expectedCleanRoundTrip(amountIn, buyPool, sellPool) {
+  const tokenMid = getAmountOut(amountIn, buyPool.reserveBase, buyPool.reserveToken, buyPool.feeBps);
+  if (tokenMid <= 0n) return { tokenMid: 0n, baseBack: 0n };
+  const baseBack = getAmountOut(tokenMid, sellPool.reserveToken, sellPool.reserveBase, sellPool.feeBps);
+  return { tokenMid, baseBack };
+}
+
+/**
+ * Derive the measured sell/transfer tax from a real round-trip vs the clean expectation.
+ *
+ * Both legs already pay the V2 swap fee (it's inside getAmountOut and inside the real
+ * router quote), so the clean baseline ALREADY nets those out. Any *additional* shortfall is
+ * the token's own transfer tax / sell-block skim. We clamp to [0,1]: a tiny positive (real >
+ * expected) can happen from rounding and is reported as 0 tax.
+ *
+ * @param {bigint} expectedBaseBack - clean CPMM baseline.
+ * @param {bigint} realBaseBack - what the chain actually returns.
+ * @returns {number} tax as a fraction in [0,1].
+ */
+function measuredTaxFromRoundTrip(expectedBaseBack, realBaseBack) {
+  if (expectedBaseBack <= 0n) return 1; // can't even compute a baseline → treat as total loss
+  if (realBaseBack >= expectedBaseBack) return 0;
+  const shortfall = expectedBaseBack - realBaseBack;
+  // fraction = shortfall / expected, computed in float on already-small token magnitudes.
+  const frac = Number(ethers.formatUnits(shortfall, 18)) / Number(ethers.formatUnits(expectedBaseBack, 18));
+  if (!Number.isFinite(frac)) return 1;
+  return Math.min(1, Math.max(0, frac));
+}
+
+/**
+ * eth_call-based real PER-TOKEN base<->token round-trip QUOTE via a V2 router's getAmountsOut.
+ *
+ * This probes ONE token over the 2-hop path base->token->base (NOT a whole candidate cycle).
+ * For a token with fee-on-transfer applied inside its own transfer(), getAmountsOut on a
+ * SupportingFeeOnTransfer-aware router does NOT reflect the tax (it uses the library
+ * formula). So we do the strongest stateless thing available: quote base->token then
+ * token->base and compare to the clean base<->token baseline. The residual catches taxes that
+ * the PAIR applies (sync/skim mismatch) and any router that does reflect them; the full
+ * holder-state tax requires the fork path (TODO). A SELL-leg revert (with a healthy buy) is
+ * the honeypot tell and needs no baseline — it flags the token regardless of its position in
+ * any cycle.
+ *
+ * @param {ethers.Provider} provider
+ * @param {object} args
+ * @param {string} args.router - V2 router address (must be set; else we fall back to pair math only).
+ * @param {string} args.baseToken
+ * @param {string} args.token - the long-tail token under test.
+ * @param {bigint} args.amountIn
+ * @returns {Promise<{ ok:boolean, sellReverted:boolean, realBaseBack:bigint, tokenMid:bigint, error?:string }>}
+ */
+async function quoteRoundTripViaRouter(provider, args) {
+  const { router, baseToken, token, amountIn } = args;
+  if (!router) {
+    return { ok: false, sellReverted: false, realBaseBack: 0n, tokenMid: 0n, error: 'no router configured' };
+  }
+  const r = new ethers.Contract(router, ROUTER_ABI, provider);
+  let tokenMid = 0n;
+  try {
+    // BUY leg quote: base -> token.
+    const buyAmounts = await r.getAmountsOut(amountIn, [baseToken, token]);
+    tokenMid = BigInt(buyAmounts[buyAmounts.length - 1]);
+  } catch (err) {
+    // A failing BUY quote means the pool/route doesn't exist or the token blocks buys too;
+    // either way it's unusable. Not the classic honeypot (which lets you buy), but unsafe.
+    return { ok: false, sellReverted: false, realBaseBack: 0n, tokenMid: 0n, error: `buy quote failed: ${err.message}` };
+  }
+  if (tokenMid <= 0n) {
+    return { ok: false, sellReverted: false, realBaseBack: 0n, tokenMid: 0n, error: 'buy quote returned 0' };
+  }
+  try {
+    // SELL leg quote: token -> base. A revert here, with a healthy buy, is the honeypot tell.
+    const sellAmounts = await r.getAmountsOut(tokenMid, [token, baseToken]);
+    const realBaseBack = BigInt(sellAmounts[sellAmounts.length - 1]);
+    return { ok: true, sellReverted: false, realBaseBack, tokenMid };
+  } catch (err) {
+    return { ok: false, sellReverted: true, realBaseBack: 0n, tokenMid, error: `sell quote reverted: ${err.message}` };
+  }
+}
+
+/**
+ * SEAM for the exact, forked-EVM round-trip. Funds a throwaway EOA with baseToken via state
+ * override, executes the real buy, then the real sell, and reads the actual delta. Only this
+ * path catches holder-state / tx.origin / whitelist honeypots that a stateless quote misses.
+ *
+ * STATUS: TODO — not implemented here because it requires a forked-EVM endpoint (anvil
+ * `--fork-url`, foundry, or a revm binding) plus eth_call state overrides / impersonation,
+ * none of which are available in this skeleton. When `forkUrl` is provided we still return
+ * `implemented:false` so callers (and the report) are never misled into trusting a number
+ * that wasn't produced. Wiring this is the single biggest fidelity upgrade for PLAY #4.
+ *
+ * @param {object} _args - { forkUrl, baseToken, token, amountIn, buyRouter, sellRouter }.
+ * @returns {Promise<{ implemented:false, reason:string }>}
+ */
+async function simulateOnFork(_args) {
+  return {
+    implemented: false,
+    reason:
+      'TODO(fork): true buy-then-sell needs anvil/foundry/revm fork + state-override funding ' +
+      'and execution. Using the eth_call getAmountsOut approximation instead. See module header.'
+  };
+}
+
+/**
+ * Best-effort probe: does the token expose an owner (i.e. someone who *could* flip fees / set
+ * a max-tx after launch)? This does not prove malice — most tokens have an owner — but a
+ * fresh-pool token with a live owner is a fee-flip RISK we surface as a soft reason, never a
+ * hard fail on its own. TODO: replay setFee/transfer-limit setter history for a real verdict.
+ *
+ * @param {ethers.Provider} provider
+ * @param {string} token
+ * @returns {Promise<{ hasOwner:boolean, owner:string|null }>}
+ */
+async function probeOwnership(provider, token) {
+  const c = new ethers.Contract(token, TOKEN_PROBE_ABI, provider);
+  for (const fn of ['owner', 'getOwner']) {
+    try {
+      const o = await c[fn]();
+      if (o && o !== ethers.ZeroAddress) return { hasOwner: true, owner: ethers.getAddress(o) };
+      return { hasOwner: false, owner: ethers.ZeroAddress };
+    } catch (_err) {
+      // try next
+    }
+  }
+  return { hasOwner: false, owner: null };
+}
+
+/**
+ * The PUBLIC token-safety check. Stable interface: { safe, reasons[], measuredSellTax, ... }.
+ *
+ * Pure-input mode (no provider): if `opts.reservesForExpected` and a precomputed
+ * `opts.realRoundTrip` are supplied, the function is fully offline and unit-testable — it
+ * runs the exact same classification logic the live path uses. This is how the demo and tests
+ * exercise the guard with zero RPC.
+ *
+ * Live mode (provider given): performs the eth_call round-trip quote, the (TODO) fork seam,
+ * the max-tx divergence probe, and the ownership probe, then classifies.
+ *
+ * @param {object} input
+ * @param {ethers.Provider} [input.provider] - omit for pure offline classification.
+ * @param {string} [input.router] - V2 router for getAmountsOut (live mode).
+ * @param {string} input.baseToken
+ * @param {string} input.token
+ * @param {bigint} input.amountIn - base-token probe amount (wei).
+ * @param {object} [input.buyPool]  - { reserveBase, reserveToken, feeBps } clean baseline for the
+ *        token's DIRECT base<->token pool (base->token). Omit/null for an interior token with no
+ *        direct base pairing: tax is then left unmeasured but the honeypot/sell-revert probe
+ *        (which needs no baseline) still runs.
+ * @param {object} [input.sellPool] - { reserveToken, reserveBase, feeBps } same base<->token pool
+ *        (token->base). Must describe the SAME venue as buyPool, NOT an interior cycle hop.
+ * @param {object} [input.precomputed] - offline test injection:
+ *        { realBaseBack:bigint, sellReverted?:boolean, largeRealBaseBack?:bigint, hasOwner?:boolean }.
+ * @param {object} [cfg] - config.tokenSafety overrides (see DEFAULTS).
+ * @returns {Promise<{
+ *   safe:boolean, reasons:string[], measuredSellTax:number,
+ *   honeypot:boolean, maxTxSuspected:boolean, feeFlipRisk:boolean,
+ *   fidelity:'fork'|'eth_call'|'offline', expectedBaseBackWei:string, realBaseBackWei:string
+ * }>}
+ */
+async function checkToken(input, cfg = {}) {
+  const c = { ...DEFAULTS, ...(cfg || {}) };
+  const reasons = [];
+  let honeypot = false;
+  let maxTxSuspected = false;
+  let feeFlipRisk = false;
+
+  const amountIn = BigInt(input.amountIn);
+
+  // 1) Clean CPMM baseline (always computable if reserves are provided).
+  let expected = { tokenMid: 0n, baseBack: 0n };
+  const haveBaseline = input.buyPool && input.sellPool;
+  if (haveBaseline) {
+    expected = expectedCleanRoundTrip(
+      amountIn,
+      { reserveBase: BigInt(input.buyPool.reserveBase), reserveToken: BigInt(input.buyPool.reserveToken), feeBps: input.buyPool.feeBps },
+      { reserveToken: BigInt(input.sellPool.reserveToken), reserveBase: BigInt(input.sellPool.reserveBase), feeBps: input.sellPool.feeBps }
+    );
+  }
+
+  // 2) Obtain the REAL round-trip result. Priority: fork (TODO) > eth_call quote > injected.
+  let fidelity = 'offline';
+  let realBaseBack = 0n;
+  let sellReverted = false;
+
+  if (input.precomputed && typeof input.precomputed.realBaseBack !== 'undefined') {
+    // Offline/test injection — exercise the SAME classifier deterministically.
+    realBaseBack = BigInt(input.precomputed.realBaseBack);
+    sellReverted = !!input.precomputed.sellReverted;
+    fidelity = 'offline';
+  } else if (input.provider) {
+    // (Attempt the exact fork path first; it self-reports unimplemented today.)
+    const fork = await simulateOnFork({
+      forkUrl: input.forkUrl,
+      baseToken: input.baseToken,
+      token: input.token,
+      amountIn
+    });
+    if (fork.implemented) {
+      fidelity = 'fork';
+      realBaseBack = BigInt(fork.realBaseBack);
+      sellReverted = !!fork.sellReverted;
+    } else {
+      // eth_call approximation.
+      const q = await quoteRoundTripViaRouter(input.provider, {
+        router: input.router,
+        baseToken: input.baseToken,
+        token: input.token,
+        amountIn
+      });
+      fidelity = 'eth_call';
+      if (!q.ok) {
+        sellReverted = q.sellReverted;
+        if (q.sellReverted) {
+          honeypot = true;
+          reasons.push(`HONEYPOT: BUY quoted fine but SELL leg reverted (${q.error}).`);
+        } else {
+          reasons.push(`UNQUOTABLE: round-trip quote failed (${q.error}). Treating as unsafe.`);
+        }
+      } else {
+        realBaseBack = q.realBaseBack;
+      }
+    }
+  } else {
+    // No provider and no injection: we can only return the offline baseline as advisory.
+    reasons.push('NO-DATA: no provider and no precomputed round-trip — offline baseline only.');
+  }
+
+  // 3) Honeypot rule for the explicit injection path too.
+  if (sellReverted && !honeypot) {
+    honeypot = true;
+    reasons.push('HONEYPOT: SELL leg reverted on a non-trivial buy.');
+  }
+
+  // 4) Measure the tax from real-vs-expected (only meaningful with a baseline and a real sell).
+  let measuredSellTax = 0;
+  if (honeypot) {
+    measuredSellTax = 1; // unsellable == 100% loss on the token leg
+  } else if (haveBaseline && realBaseBack > 0n) {
+    measuredSellTax = measuredTaxFromRoundTrip(expected.baseBack, realBaseBack);
+    if (measuredSellTax > c.maxSellTax) {
+      reasons.push(
+        `SELL-TAX: measured base<->token round-trip tax ${(measuredSellTax * 100).toFixed(2)}% > ` +
+          `${(c.maxSellTax * 100).toFixed(2)}% limit (fee-on-transfer / transfer-tax).`
+      );
+    }
+  } else if (!honeypot && !haveBaseline) {
+    reasons.push('TAX-UNMEASURED: no CPMM baseline (reserves) supplied — tax not quantified.');
+  }
+
+  // 5) Max-tx / size-dependent-tax probe: re-probe the SAME base<->token round-trip at a larger
+  // size. Two independent signals:
+  //   (a) SELL-REVERT-AT-SIZE — fine small, reverts large → max-tx / anti-whale gate. This needs
+  //       NO baseline, so it runs for ANY non-base token in live eth_call mode (interior tokens
+  //       on a longer cycle included).
+  //   (b) GRADUATED TAX — the measured tax JUMPS beyond what price impact explains. This is a
+  //       relative comparison against the clean baseline, so it requires haveBaseline.
+  // Offline tests drive (b) via precomputed.largeRealBaseBack.
+  if (!honeypot && (haveBaseline || (input.provider && fidelity === 'eth_call'))) {
+    let largeReal = null;
+    const largeIn = amountIn * BigInt(c.largeProbeMultiplier);
+    const largeExpected = haveBaseline
+      ? expectedCleanRoundTrip(
+          largeIn,
+          { reserveBase: BigInt(input.buyPool.reserveBase), reserveToken: BigInt(input.buyPool.reserveToken), feeBps: input.buyPool.feeBps },
+          { reserveToken: BigInt(input.sellPool.reserveToken), reserveBase: BigInt(input.sellPool.reserveBase), feeBps: input.sellPool.feeBps }
+        )
+      : { tokenMid: 0n, baseBack: 0n };
+    if (input.precomputed && typeof input.precomputed.largeRealBaseBack !== 'undefined') {
+      largeReal = BigInt(input.precomputed.largeRealBaseBack);
+    } else if (input.provider && fidelity === 'eth_call') {
+      const q2 = await quoteRoundTripViaRouter(input.provider, {
+        router: input.router,
+        baseToken: input.baseToken,
+        token: input.token,
+        amountIn: largeIn
+      });
+      if (q2.sellReverted) {
+        // (a) Sells fine small but reverts large → classic max-tx / anti-whale honeypot variant.
+        // Baseline-independent, so this guards interior tokens of longer cycles too.
+        maxTxSuspected = true;
+        reasons.push('MAX-TX: SELL reverts at a larger size but not a small one (per-tx limit / anti-whale).');
+      } else if (q2.ok) {
+        largeReal = q2.realBaseBack;
+      }
+    }
+    // (b) Graduated-tax comparison only when we have an apples-to-apples baseline.
+    if (haveBaseline && largeReal !== null && largeExpected.baseBack > 0n) {
+      const largeTax = measuredTaxFromRoundTrip(largeExpected.baseBack, largeReal);
+      if (largeTax - measuredSellTax > c.taxConsistencyTolerance) {
+        maxTxSuspected = true;
+        reasons.push(
+          `MAX-TX/GRADUATED-TAX: tax rises from ${(measuredSellTax * 100).toFixed(2)}% (small) to ` +
+            `${(largeTax * 100).toFixed(2)}% (×${c.largeProbeMultiplier} size) beyond price impact.`
+        );
+      }
+    }
+  }
+
+  // 6) Fee-flip RISK (soft): a live owner can mutate fees/limits after launch. Heuristic only.
+  let hasOwner = false;
+  if (input.precomputed && typeof input.precomputed.hasOwner !== 'undefined') {
+    hasOwner = !!input.precomputed.hasOwner;
+  } else if (input.provider) {
+    const own = await probeOwnership(input.provider, input.token);
+    hasOwner = own.hasOwner;
+  }
+  if (hasOwner) {
+    feeFlipRisk = true;
+    reasons.push(
+      'FEE-FLIP-RISK(soft): token has a live owner that COULD set fees / max-tx post-launch. ' +
+        'TODO(temporal): replay setter history to confirm. Not a hard fail by itself.'
+    );
+  }
+
+  // 7) Final verdict. Hard fails: honeypot, sell-tax over limit, max-tx, or unquotable.
+  const hardFail =
+    honeypot ||
+    maxTxSuspected ||
+    measuredSellTax > c.maxSellTax ||
+    reasons.some((r) => r.startsWith('UNQUOTABLE')) ||
+    reasons.some((r) => r.startsWith('HONEYPOT'));
+
+  return {
+    safe: !hardFail,
+    reasons,
+    measuredSellTax,
+    honeypot,
+    maxTxSuspected,
+    feeFlipRisk,
+    fidelity,
+    expectedBaseBackWei: expected.baseBack.toString(),
+    realBaseBackWei: realBaseBack.toString()
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  ROUTER_ABI,
+  PAIR_ABI,
+  expectedCleanRoundTrip,
+  measuredTaxFromRoundTrip,
+  quoteRoundTripViaRouter,
+  simulateOnFork,
+  probeOwnership,
+  checkToken
+};

--- a/solvers/cow/README.md
+++ b/solvers/cow/README.md
@@ -1,0 +1,188 @@
+# CoW Protocol solver — BofhContractV2 filler (SCAFFOLD)
+
+> Status: **runnable skeleton, not a money printer.** This directory wires the existing
+> BofhContractV2 + off-chain research toolkit into the shape of a CoW Protocol *solver*. It
+> proves the *plumbing*, not an *edge*. Earning rewards is gated on (a) passing CoW's KYC, (b)
+> a Gate-0-style live validation that the opportunity actually exists net-of-everything, and
+> (c) a contract change to handle generic fills (see "Known limits" below). Read this whole
+> file before doing anything with real keys or bonds.
+
+---
+
+## 1. What a CoW solver is (and where Bofh fits)
+
+CoW Protocol runs a **batch auction**. Users sign orders (gasless, off-chain). A **solver
+competition** then finds the settlement that gives users the most surplus. Two components:
+
+- **Driver** — CoW infrastructure. For bonding-pool members it is *managed by the CoW team*.
+  It fetches liquidity, generates on-chain submission keys, runs EBBO fairness checks, can
+  merge disjoint solutions, picks the winner, and submits the settlement tx. **We do not build
+  this.**
+- **Solver engine** — *our* HTTP service. The driver `POST`s a batch auction to
+  `{base_url}/${env}/${network}/solve`; we return `{ "solutions": [...] }`. That transform is
+  what `solve.js` implements.
+
+**The reuse, stated plainly:**
+
+| Role in a CoW solver        | This repo's asset                                   |
+|-----------------------------|-----------------------------------------------------|
+| **Interaction contract**    | `BofhContractV2` — the non-custodial executor the CoW `GPv2Settlement` calls via a custom interaction. It pulls the sell/base token from Settlement and returns the bought token *in the same tx*. |
+| **Solution engine**         | `research/pathfinder.js` (Bellman-Ford negative-cycle finder over the V2-fork registry). |
+| **Solution scorer**         | `research/backtester.js` + `gasModel.js` — net-of-gas USD; we only emit a solution with strictly positive net surplus. |
+| **Token-safety gate**       | `config.tokenAllowlist` (fail-closed). This is the off-chain analogue of the report's token-safety simulator — until that simulator exists, the allowlist is the only thing standing between you and a honeypot/fee-on-transfer token. |
+
+`BofhContractV2` is the **commodity settlement leg** the deep-research report described. The CoW
+*solver role* is one of the two places the report said the value actually lives (the other being
+sealed-bid on-chain backrun auctions). This scaffold is the on-ramp to that role.
+
+---
+
+## 2. Economics (verify before trusting any number)
+
+CoW solver rewards come from two pools, both paid in **COW** (rewards address must be controlled
+by your team **on both the solving chain and on mainnet**).
+
+**Performance rewards** — confirmed from the rewards reference doc:
+```
+performanceReward_i = cap( totalScore − referenceScore_i − missingScore_i )
+```
+The `cap` is per-chain. For **Ethereum / Arbitrum / Base**: `β = 50%`, `cap floor cl = 0.010 ETH`.
+Gnosis/Polygon/Plasma use `β = 100%` with native-token floors; Avalanche/BNB/Linea/Ink likewise.
+Net: your reward per batch is bounded — you cannot win an unbounded amount on one batch, and you
+are scored *relative to the next-best solver* (`referenceScore`). Being the only solver on a
+long-tail batch is where the marginal reward concentrates.
+
+**Consistency rewards** — a separate budget split *proportional to the number of executed orders
+you submitted a solution for*. Rewards turning up requires **showing up consistently**, not just
+occasionally sniping.
+
+**Quote/price-estimation competition** — optional separate program; quote rewards range from
+`min{0.00003 ETH, 6 COW}` to `min{0.0007 ETH, 6 COW}` per chain.
+
+**Bonding-pool service fee** — confirmed: members of a managed bonding pool pay **15% of weekly
+COW rewards** as a service fee, **beginning ~6 months after joining**.
+
+> ⚠️ **Figures I could NOT confirm against the live docs (2026-06):** the **"CIP-85 long-tail
+> rewards"** label and the **"~25% bond"** number from the project brief did **not** appear in
+> the rewards reference page I fetched. The bond is real in spirit — you must keep a native-token
+> balance on your submission address (see runbook) and a bonding pool backs your solver's
+> penalties — but treat the *exact* "25%" and the *exact* "CIP-85" mechanism as **TODO: re-verify
+> against the current CIP index** before quoting them to anyone or sizing a bond. Do not put real
+> money behind an unverified percentage.
+
+**Bottom line:** rewards are capped-per-batch, relative-to-competition, paid in a volatile token
+(COW), reduced by a 15% pool fee after 6 months, and require *consistent* participation. The edge
+has to survive all of that *and* gas. Prove it on real data first.
+
+---
+
+## 3. Real onboarding runbook (in order — do NOT skip)
+
+From CoW's solver onboarding doc. **Arbitrum is required first**; mainnet comes only after an L2
+track record.
+
+| Stage | Network | Native balance to keep | What happens |
+|-------|---------|------------------------|--------------|
+| 0. Local dev | — | — | Build the engine locally; replay auctions. |
+| 1. **Shadow** | Arbitrum + mainnet | none (no settlement) | Driver feeds you *production* auctions; your solutions are scored but **never settled on-chain**. This is the free, no-risk edge-proof. **Stay here until shadow shows real, repeatable net-positive solutions.** |
+| 2. **KYC** | — | — | Submit incorporation details + shareholder list + **1–2 passports of main shareholders/devs**; name your solver in the email. Takes **1–3 working days**. |
+| 3. **Staging (Barn)** | **Arbitrum** | **~0.05 ETH** | Live on-chain settlement, low volume. |
+| 4. **Production** | **Arbitrum** | **~0.2 ETH** | Full orderflow competition. |
+| (later) Mainnet | mainnet | staging 0.2 ETH / prod 1 ETH | Only after Arbitrum track record. |
+
+Other chains' balances for reference: Base 0.05/0.2 ETH (staging/prod); Gnosis 15/100 xDAI.
+
+**Engine endpoint format the driver expects:** `{base_url}/${env}/${network}`
+e.g. `https://api.your-solver.io/staging/arbitrum-one` → it `POST`s `/solve` there.
+Networks string set includes `arbitrum-one, base, bnb, mainnet, xdai, optimism, polygon, sepolia, …`.
+
+**Gate-0 (CRITICAL, do this before staging/bonding):** the research report flagged that Chainlink
+**acquired Atlas (22 Jan 2026)** and pivoted toward SVR-liquidation flow. CoW is a *different* OFA,
+but the same risk applies: **confirm the permissionless solver competition is still open to new,
+KYC'd-but-independent solvers on Arbitrum, and that long-tail DEX-backrun orderflow still reaches
+solvers,** *before* you spend on KYC/bond. If the orderflow has been captured by privileged
+solvers or routed elsewhere, the whole play is dead on arrival. **Verify live; do not assume.**
+
+---
+
+## 4. Files
+
+| File | What it is |
+|------|------------|
+| `solve.js` | The solver engine `solve(auction) -> { solutions }` transform + a `--demo` harness. Parses a CoW batch auction, gates orders through the allowlist, routes via the pathfinder, scores net-of-gas, builds the CoW solution JSON. |
+| `settlement.js` | Encodes a routed path into `BofhContractV2.executeSwapMultiDex(...)` calldata and wraps it as CoW `custom` interaction tuple(s) (approve + swap), with `inputs/outputs/allowances`. |
+| `config.example.json` | Chain (Arbitrum), CoW endpoints (via **env vars**, never inline secrets), interaction-contract address, mirrored DexRegistry, and the token allowlist. |
+
+### Run the skeleton (no RPC, no keys)
+```bash
+node --check solvers/cow/solve.js
+node --check solvers/cow/settlement.js
+node solvers/cow/solve.js --demo
+```
+The `--demo` path reuses `research/run.js`'s synthetic snapshot so the cycle finder yields a route
+and you can see a real CoW-shaped solution come out. `0 solutions` is *also* a valid outcome
+(the net-of-gas gate is doing its job).
+
+---
+
+## 5. Known limits & honest TODOs (read before believing this works)
+
+1. **V2-only liquidity limit (structural).** `BofhContractV2` routes solely over Uniswap-V2-fork
+   pools in its owned `DexRegistry`. CoW batches clear against the *whole* market — Uni-V3, Curve,
+   Balancer, native CoW-AMM, plus other solvers' liquidity. A V2-only solver will **lose most
+   competitive batches** to solvers with full-market liquidity. The realistic niche is **long-tail
+   / fresh V2-fork pools** where V3-class liquidity is thin — exactly the report's thesis, and a
+   small slice of total flow.
+2. **The contract is an arb executor, not a generic A→B router (blocking).**
+   `executeSwapMultiDex` requires `path[0] == path[last] == baseToken` and pulls `baseToken` from
+   `msg.sender`. So today it can only settle a **baseToken-in / baseToken-out** leg (i.e. an
+   arbitrage/backrun cycle surfaced inside the batch), **not** an arbitrary user fill
+   (sell USDC → buy PEPE). `routeOrder` honestly **returns null and skips** any non-baseToken
+   order rather than mis-encoding one. Generic fills need a **contract change** (a `swapExactIn`
+   entrypoint that takes `(tokenIn, tokenOut, amountIn, minOut, path...)` and pays the recipient).
+   **TODO + flagged loudly** in `settlement.js`.
+   Path-length constraint: the contract's `MAX_PATH_LENGTH` is **6** (6 tokens), and a route's
+   **hop count = path.length − 1**, so any settlable route is **≤ 5 hops** (≤ 6 tokens). Set
+   `config.pathfinder.maxHops ≤ 5` accordingly. (Earlier drafts of this README/config said
+   `MAX_PATH_LENGTH (5)` — that was wrong; it is 6 tokens / 5 hops.)
+3. **KYC = permanent loss of anonymity.** Onboarding requires **passports of the main
+   shareholders/devs** and full incorporation/shareholder disclosure to a third party. This is
+   irreversible. For a searcher operation that has so far been pseudonymous, this is the single
+   biggest non-technical cost. Decide *before* shadow whether you are willing to be doxxed to CoW.
+4. **No real driver / HTTP server.** `solve.js` is the pure transform only. A production engine
+   needs an HTTP server (express/fastify — **not installed; do not add deps without sign-off**)
+   bound at `{env}/{network}/solve`, plus the driver auth secret from onboarding. **TODO(real).**
+5. **No live reserves.** Routing needs a pool snapshot. `scanner.js` produces it but needs RPC; the
+   `--demo` path uses a synthetic snapshot. A real run must feed a fresh, block-current snapshot
+   (stale reserves → reverts → wasted gas + reputation hit). **TODO(real).**
+6. **Token-safety is an allowlist, not a simulator.** The fee-on-transfer / honeypot / rebasing
+   protection here is *only* `config.tokenAllowlist` (fail-closed). The report's actual
+   token-safety *simulator* is **not implemented**. Do **not** widen the allowlist to long-tail
+   tokens until that simulator exists and each token passes it.
+7. **Gas + reward numbers are placeholders.** `gasModel.js` constants are conservative guesses;
+   the COW reward figures move with the token price; the bond percentage is unverified (§2). Net
+   surplus shown is *indicative*, not *bankable*.
+8. **Prove → strip → audit (discipline).** Per the research mandate: prove the edge in **shadow**
+   on real auctions *first*; only then consider whether the fat `BofhContractV2` should be stripped
+   to a lean executor (its gas may erase the long-tail edge — that's the whole point of the
+   fat-vs-lean comparison in `backtester.js`); audit **last**, before any production bond.
+9. **Integration risk: `antiMEV` rate-limits a repeatedly-firing solver.**
+   `BofhContractV2.executeSwapMultiDex` (our interaction entrypoint) carries the **`antiMEV`**
+   modifier, which — *when enabled* — enforces a **per-block transaction cap** (`maxTxPerBlock`,
+   default 3) **and a `minTxDelay`** (default 12s) **per calling address**. A CoW solver wins
+   batches back-to-back and the settlement calls our contract from the **same `GPv2Settlement`
+   address** every time, so an enabled `antiMEV` would **revert** the second-or-later settlement
+   in a window — silently turning wins into failed settlements (wasted gas + a reputation/penalty
+   hit). `mevProtectionEnabled` is a `bool` with **no initializer, so it is OFF by default**, but
+   this is an **operational contract**: whoever owns the deployed interaction contract **MUST keep
+   `antiMEV` disabled, or size `maxTxPerBlock`/`minTxDelay` to the solver's win cadence** (e.g. via
+   `configureMEVProtection`). Treat this as a deploy-time checklist item — verify
+   `getMEVProtectionConfig()` before any staging/prod run. (This anti-MEV guard makes sense for the
+   contract's standalone arb use, but is actively hostile to its use as a high-frequency CoW
+   interaction contract.)
+
+---
+
+*This scaffold deliberately makes it easy to say "no". If shadow mode doesn't show a repeatable,
+net-of-gas-positive, V2-reachable edge, the correct outcome is to stop here — before KYC, before a
+bond, before an audit.*

--- a/solvers/cow/config.example.json
+++ b/solvers/cow/config.example.json
@@ -1,0 +1,82 @@
+{
+  "_comment": "Example config for the BofhContractV2-backed CoW Protocol solver SCAFFOLD. Copy to config.json and fill in real values. SECRETS (driver auth, rewards key) NEVER live here — they come from env vars named below.",
+
+  "env": "staging",
+  "_env_note": "one of: shadow | staging (barn) | prod. Drives which CoW driver/orderbook the loop talks to. The real driver endpoint is {base}/${env}/${network} — see README onboarding runbook.",
+
+  "chain": {
+    "key": "arbitrum",
+    "_key_note": "CoW requires Arbitrum FIRST for staging+prod. addresses use arbitrum-one in the CoW network table.",
+    "chainId": 42161,
+    "network": "arbitrum-one",
+    "nativeSymbol": "ETH",
+    "rpcEnv": "ARBITRUM_RPC_URL",
+    "_rpcEnv_note": "TODO(real): export ARBITRUM_RPC_URL=https://... — never hardcode the URL here."
+  },
+
+  "cow": {
+    "_cow_note": "These are the CoW driver/orderbook endpoints. The DRIVER (CoW infra, managed for bonding-pool members) POSTs /solve to OUR engine; it is not an endpoint we call. We expose an HTTP server; CoW pulls from us. The orderbook/api below is for read-only inspection during shadow.",
+    "solverEngineBindEnv": "COW_SOLVER_BIND",
+    "_solverEngineBind_note": "host:port this scaffold's HTTP server binds to so the CoW driver can POST /${env}/${network}/solve. TODO(real): wire an actual HTTP server (express/fastify) — not installed; see README.",
+    "orderbookApiEnv": "COW_ORDERBOOK_API",
+    "_orderbookApi_note": "e.g. https://api.cow.fi/arbitrum_one — read-only, for shadow-mode auction inspection.",
+    "driverAuthEnv": "COW_DRIVER_AUTH_TOKEN",
+    "_driverAuth_note": "TODO(real): bearer/shared-secret the driver uses to authenticate /solve requests, issued during onboarding.",
+    "rewardsAddressEnv": "COW_REWARDS_ADDRESS",
+    "_rewardsAddress_note": "address controlled by the solver team that receives COW rewards. MUST be controlled on BOTH the solving chain AND mainnet (per onboarding)."
+  },
+
+  "interactionContract": {
+    "_note": "BofhContractV2 deployed on the solving chain. It is the non-custodial INTERACTION contract the settlement calls via a custom interaction. The CoW Settlement contract transfers sell tokens to it, it routes the swap across the V2-fork registry, and returns buy tokens.",
+    "address": "0x0000000000000000000000000000000000000000",
+    "_address_note": "TODO(real): deploy BofhContractV2 to Arbitrum and put its address here. The zero address is a placeholder and will make the scaffold emit a config error.",
+    "abiEntrypoint": "executeSwapMultiDex(address[],uint256[],uint16[],uint256,uint256,uint256)"
+  },
+
+  "settlementContract": {
+    "_note": "Canonical CoW Settlement (GPv2Settlement) on the solving chain. The interaction is executed BY this contract, so token balances live here at interaction time.",
+    "address": "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
+    "_address_note": "GPv2Settlement is the same address across most CoW chains incl. Arbitrum. VERIFY on the explorer before any real run."
+  },
+
+  "dexRegistry": {
+    "_note": "Mirror of the on-chain BofhContractV2 owner-managed DexRegistry (dexId -> {factory, feeBps}). Used off-chain by the pathfinder to score routes. MUST match the on-chain registry or settlements will revert.",
+    "dexIds": {
+      "0": { "name": "immutable-factory", "factory": "0x0000000000000000000000000000000000000000", "feeBps": 30 },
+      "1": { "name": "example-v2-fork", "factory": "0x0000000000000000000000000000000000000000", "feeBps": 25 }
+    },
+    "_dexIds_note": "TODO(real): populate with the actual Arbitrum V2-fork factories you have registered on-chain."
+  },
+
+  "tokenAllowlist": {
+    "_note": "GATE: only orders whose sell+buy tokens are BOTH on this list are solved. This is the off-chain analogue of the token-safety simulator gate from the research report — it bounds honeypot/fee-on-transfer exposure. Empty list = solve nothing (fail closed).",
+    "tokens": [
+      "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "0xfd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9"
+    ],
+    "_tokens_note": "WETH, USDC.e, USDC, USDT on Arbitrum as a conservative seed. Add long-tail tokens only after each passes the token-safety simulator (TODO). Symbols are NOT checked — addresses are authoritative."
+  },
+
+  "pathfinder": {
+    "_note": "Forwarded to research/pathfinder.js findCandidateCycles. maxHops MUST be <= 5 so any route is settlable: the contract's MAX_PATH_LENGTH is 6 TOKENS = 5 HOPS, and a hop count = path.length - 1.",
+    "maxHops": 4,
+    "minHops": 2,
+    "topN": 25
+  },
+
+  "gas": {
+    "_note": "Forwarded to research/gasModel.js + backtester.js for net-of-gas scoring. Placeholder figures — TODO(measure) with REPORT_GAS=true and live base-fee.",
+    "baseFeeGwei": 0.05,
+    "priorityFeeGwei": 0.01,
+    "nativeUsdPrice": 3000
+  },
+
+  "scoring": {
+    "_note": "A solution is only returned if its net-of-gas surplus is strictly positive. minNetSurplusUsd is an extra safety margin so we never submit a marginal (likely-to-revert-or-lose) solution. This OFF-CHAIN net-of-gas gate is the REAL economic guard — the on-chain minAmountOut only enforces break-even round-trip by default (see below).",
+    "minNetSurplusUsd": 0.50,
+    "minOnchainProfitBps": 0,
+    "_minOnchainProfitBps_note": "On-chain minAmountOut floor in bps over amountIn. 0 = break-even only (the contract guards a stale-reserve revert, not a losing trade — the off-chain net-of-gas score above is the economic guard, and CoW won't submit a losing solution). Set >0 for belt-and-suspenders defence against bad off-chain scoring."
+  }
+}

--- a/solvers/cow/settlement.js
+++ b/solvers/cow/settlement.js
@@ -1,0 +1,179 @@
+'use strict';
+
+/**
+ * CoW <-> BofhContractV2 settlement bridge.
+ *
+ * RESPONSIBILITY: turn a routed arbitrage/fill (a baseToken-anchored V2-fork path resolved
+ * by the pathfinder) into the exact CoW "custom interaction" tuple that the GPv2Settlement
+ * contract will execute, by encoding a call to BofhContractV2.executeSwapMultiDex(...).
+ *
+ * HOW THE PIECES FIT (non-custodial, single tx):
+ *   GPv2Settlement (holds the order's sell tokens after the trade transfer-in)
+ *     --[ custom interaction: approve sellToken to BofhContractV2 ]-->
+ *     --[ custom interaction: executeSwapMultiDex(...) ]-->
+ *        BofhContractV2 pulls sellToken from Settlement (msg.sender == Settlement),
+ *        routes across the V2-fork DexRegistry, returns buyToken to Settlement in-tx.
+ *   Settlement then pays out the order using its now-increased buyToken balance.
+ *
+ * The CoW solver `interactions` array (CustomInteraction variant, per the solver openapi.yml)
+ * has the shape:
+ *   {
+ *     kind: "custom",
+ *     target: address,            // contract the Settlement will .call()
+ *     value: TokenAmount,         // native value (decimal string, wei) — "0" here
+ *     callData: hex,              // ABI-encoded calldata
+ *     inputs:  [ { token, amount } ],  // assets this interaction CONSUMES from Settlement
+ *     outputs: [ { token, amount } ],  // assets this interaction PRODUCES to Settlement
+ *     allowances: [ { token, spender, amount } ]  // optional ERC20 approvals to set first
+ *   }
+ *
+ * NOTE on truthfulness: BofhContractV2.executeSwapMultiDex requires `path[0] == baseToken`
+ * and `path[last] == baseToken` (round-trip arb), and it pulls `amountIn` of baseToken from
+ * msg.sender. For a CoW FILL where sellToken != baseToken, the contract as-is is NOT a drop-in
+ * router — see the README "V2-only liquidity limit" + "interaction-contract shape" gates. This
+ * encoder targets the case the contract actually supports today: a baseToken-in / baseToken-out
+ * route, i.e. an arbitrage backrun surfaced inside the batch, OR an order whose sell AND buy
+ * token is the baseToken leg. Generalising to arbitrary sell/buy tokens is a contract change
+ * (TODO), flagged loudly rather than silently mis-encoded.
+ */
+
+const { ethers } = require('ethers');
+
+// Minimal ABI fragments — we only need the entrypoint and ERC20 approve for encoding.
+const BOFH_ABI = [
+  'function executeSwapMultiDex(address[] path, uint256[] fees, uint16[] dexIds, uint256 amountIn, uint256 minAmountOut, uint256 deadline) external returns (uint256)'
+];
+const ERC20_ABI = ['function approve(address spender, uint256 amount) external returns (bool)'];
+
+const bofhIface = new ethers.Interface(BOFH_ABI);
+const erc20Iface = new ethers.Interface(ERC20_ABI);
+
+// Sentinel BofhContractV2 understands for "use the registered registry feeBps for this hop".
+const REGISTRY_FEE_SENTINEL = (2n ** 256n - 1n).toString(); // type(uint256).max
+
+/**
+ * Build the executeSwapMultiDex calldata for a resolved route.
+ *
+ * @param {object} route - a routed cycle/path. Expected shape (mirrors pathfinder hops):
+ *   {
+ *     tokens:   string[],          // path addresses, length = hops+1, [0]==[last]==baseToken
+ *     hops:     Array<{ dexId?: number, feeBps?: number }>,  // length = tokens.length - 1
+ *     amountInWei:  string|bigint, // baseToken in
+ *     minAmountOutWei: string|bigint // economic backstop (the contract's real guard)
+ *   }
+ * @param {object} opts
+ * @param {number} opts.deadline - unix seconds; contract reverts if block.timestamp > deadline.
+ * @param {boolean} [opts.useRegistryFees=true] - emit the fee sentinel so on-chain registry
+ *   feeBps is authoritative (recommended; avoids off-chain/on-chain fee drift reverts).
+ * @returns {{ callData: string, path: string[], fees: string[], dexIds: number[], amountIn: string, minAmountOut: string }}
+ */
+function encodeExecuteSwapMultiDex(route, opts) {
+  if (!route || !Array.isArray(route.tokens) || route.tokens.length < 3) {
+    throw new Error('encodeExecuteSwapMultiDex: route.tokens must be a path of length >= 3 (start==end==baseToken).');
+  }
+  const path = route.tokens;
+  const hops = route.hops || [];
+  if (hops.length !== path.length - 1) {
+    throw new Error(`encodeExecuteSwapMultiDex: hops (${hops.length}) must equal path.length-1 (${path.length - 1}).`);
+  }
+  if (path[0].toLowerCase() !== path[path.length - 1].toLowerCase()) {
+    // Contract enforces this; fail here with a clear message rather than letting it revert on-chain.
+    throw new Error('encodeExecuteSwapMultiDex: path must start and end at the SAME baseToken (round-trip).');
+  }
+
+  const useRegistryFees = opts.useRegistryFees !== false;
+  const fees = hops.map((h) =>
+    useRegistryFees || h.feeBps == null ? REGISTRY_FEE_SENTINEL : BigInt(Math.round(h.feeBps)).toString()
+  );
+  const dexIds = hops.map((h) => Number(h.dexId ?? 0)); // dexId 0 = immutable factory fallback
+
+  const amountIn = BigInt(route.amountInWei).toString();
+  const minAmountOut = BigInt(route.minAmountOutWei).toString();
+  const deadline = BigInt(opts.deadline).toString();
+
+  const callData = bofhIface.encodeFunctionData('executeSwapMultiDex', [
+    path,
+    fees,
+    dexIds,
+    amountIn,
+    minAmountOut,
+    deadline
+  ]);
+
+  return { callData, path, fees, dexIds, amountIn, minAmountOut };
+}
+
+/**
+ * Build the ERC20 `approve(spender, amount)` calldata Settlement must run so BofhContractV2
+ * can transferFrom the sell/base token. We approve the exact amountIn (not unlimited) to keep
+ * the interaction minimal-trust within the batch.
+ * @param {string} spender - BofhContractV2 address.
+ * @param {string|bigint} amount
+ * @returns {string} calldata
+ */
+function encodeApprove(spender, amount) {
+  return erc20Iface.encodeFunctionData('approve', [spender, BigInt(amount).toString()]);
+}
+
+/**
+ * Produce the CoW custom-interaction TUPLE(s) for a route: an optional approve interaction
+ * followed by the executeSwapMultiDex interaction. Returns them in execution order.
+ *
+ * @param {object} route - see encodeExecuteSwapMultiDex.
+ * @param {object} ctx
+ * @param {string} ctx.interactionContract - BofhContractV2 address (the `target`).
+ * @param {number} ctx.deadline - unix seconds.
+ * @param {boolean} [ctx.includeApprove=true] - prepend an ERC20 approve interaction.
+ * @param {boolean} [ctx.useRegistryFees=true]
+ * @returns {Array<object>} CoW `interactions` entries (kind:"custom"), in order.
+ */
+function buildBofhInteractions(route, ctx) {
+  if (!ctx || !ctx.interactionContract || /^0x0{40}$/i.test(ctx.interactionContract)) {
+    throw new Error('buildBofhInteractions: ctx.interactionContract is unset/zero — deploy BofhContractV2 and set its address in config (TODO).');
+  }
+  const enc = encodeExecuteSwapMultiDex(route, {
+    deadline: ctx.deadline,
+    useRegistryFees: ctx.useRegistryFees
+  });
+
+  const baseToken = enc.path[0];
+  const interactions = [];
+
+  if (ctx.includeApprove !== false) {
+    interactions.push({
+      kind: 'custom',
+      target: baseToken, // the ERC20 we approve from Settlement's balance
+      value: '0',
+      callData: encodeApprove(ctx.interactionContract, enc.amountIn),
+      // approve consumes/produces no token *balances* from the Settlement's accounting view.
+      inputs: [],
+      outputs: [],
+      // allowances is the CoW-native way to express the same approval; we set BOTH the explicit
+      // approve call (works on every ERC20) and the structured allowance (driver may optimise).
+      allowances: [
+        { token: baseToken, spender: ctx.interactionContract, amount: enc.amountIn }
+      ]
+    });
+  }
+
+  interactions.push({
+    kind: 'custom',
+    target: ctx.interactionContract,
+    value: '0',
+    callData: enc.callData,
+    // The swap consumes amountIn of baseToken from Settlement and returns >= minAmountOut.
+    // CoW uses inputs/outputs to verify the interaction's net token movement against the batch.
+    inputs: [{ token: baseToken, amount: enc.amountIn }],
+    outputs: [{ token: baseToken, amount: enc.minAmountOut }],
+    allowances: []
+  });
+
+  return interactions;
+}
+
+module.exports = {
+  REGISTRY_FEE_SENTINEL,
+  encodeExecuteSwapMultiDex,
+  encodeApprove,
+  buildBofhInteractions
+};

--- a/solvers/cow/solve.js
+++ b/solvers/cow/solve.js
@@ -1,0 +1,336 @@
+'use strict';
+
+/**
+ * CoW Protocol solver engine — SCAFFOLD.
+ *
+ * WHAT THIS IS: the "solver engine" half of a CoW solver (the other half, the "driver", is
+ * CoW infrastructure managed for bonding-pool members — we do NOT implement it). The driver
+ * POSTs a batch auction to our engine at  {base}/${env}/${network}/solve  and expects a
+ * { "solutions": [...] } body back. This file implements that solve() transform, plus a tiny
+ * stdin/--demo harness so it is runnable offline with `node solvers/cow/solve.js --demo`.
+ *
+ * WHAT IS REAL vs TODO:
+ *   REAL: auction parsing, the allowlist gate, the route->interaction encoding (settlement.js),
+ *         net-of-gas scoring reusing research/backtester.js + gasModel.js, the CoW solution shape.
+ *   TODO(real): an actual HTTP server the driver can reach (no web framework installed — see
+ *               README); a real route over LIVE reserves (here we expect a snapshot to be
+ *               provided, mirroring research/run.js, because scanner.js needs RPC); the
+ *               token-safety simulator gate; driver auth; submission keys.
+ *
+ * IMPORTANT HONESTY (mirrors the research DISCIPLINE): this scaffold does NOT prove an edge.
+ * It is wiring. A solution is only emitted when net-of-gas surplus clears config.scoring, and
+ * the whole thing is gated on KYC + a Gate-0-style live-OFA check (see README). It is not a
+ * turnkey money printer.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// We are allowed to READ research/* to mirror interfaces. We reuse the path-finding +
+// net-of-gas scoring engines verbatim rather than reimplementing them.
+const { findCandidateCycles } = require('../../research/pathfinder.js');
+const { optimalInput, weiToUsd } = require('../../research/backtester.js');
+const { gasCostForCycle } = require('../../research/gasModel.js');
+const { buildBofhInteractions } = require('./settlement.js');
+
+const CONFIG_PATH = path.join(__dirname, 'config.json');
+const EXAMPLE_PATH = path.join(__dirname, 'config.example.json');
+
+/**
+ * Load solver config, preferring config.json, falling back to the committed example so the
+ * scaffold is inspectable out of the box.
+ * @returns {{ config: object, isExample: boolean }}
+ */
+function loadConfig() {
+  const usingExample = !fs.existsSync(CONFIG_PATH);
+  const raw = fs.readFileSync(usingExample ? EXAMPLE_PATH : CONFIG_PATH, 'utf8');
+  if (usingExample) {
+    console.warn('[cow/solve] config.json not found — using config.example.json (placeholders). Copy + fill before any real run.');
+  }
+  return { config: JSON.parse(raw), isExample: usingExample };
+}
+
+/**
+ * Lowercase-set of allowlisted tokens. Fail-closed: empty allowlist solves nothing.
+ * @param {object} config
+ * @returns {Set<string>}
+ */
+function allowSet(config) {
+  const toks = (config.tokenAllowlist && config.tokenAllowlist.tokens) || [];
+  return new Set(toks.map((t) => String(t).toLowerCase()));
+}
+
+/**
+ * Gate an order through the token allowlist (the off-chain analogue of the token-safety
+ * simulator from the research report).
+ * @param {object} order - CoW Order (uid, sellToken, buyToken, ...).
+ * @param {Set<string>} allow
+ * @returns {boolean}
+ */
+function orderPassesAllowlist(order, allow) {
+  if (allow.size === 0) return false;
+  return allow.has(String(order.sellToken).toLowerCase()) && allow.has(String(order.buyToken).toLowerCase());
+}
+
+/**
+ * Route a single order over the V2-fork registry using the pathfinder.
+ *
+ * MIRROR-OF-INTERFACE NOTE: research/pathfinder.findCandidateCycles is a baseToken-anchored
+ * CYCLE finder (arb), not a generic A->B router. For this scaffold we therefore solve the case
+ * the contract supports today: orders/backruns whose sell and buy token are the configured
+ * baseToken leg, surfacing the most profitable round-trip cycle through the snapshot. Building
+ * a true sell->buy router (and a contract that accepts it) is a flagged TODO (see README/
+ * settlement.js). We DO NOT fabricate a route for an arbitrary pair — we return null and skip.
+ *
+ * @param {object} order
+ * @param {object} snapshot - scanner.js-shaped pool snapshot (REAL reserves required for truth).
+ * @param {object} config
+ * @returns {null | { tokens:string[], hops:object[], amountInWei:string, amountOutWei:string,
+ *                    minAmountOutWei:string, grossProfitWei:string }}
+ */
+function routeOrder(order, snapshot, config) {
+  const baseToken = String(snapshot.baseToken || '').toLowerCase();
+  const sell = String(order.sellToken).toLowerCase();
+  const buy = String(order.buyToken).toLowerCase();
+
+  // Only the baseToken<->baseToken case is honestly settlable by BofhContractV2 today.
+  if (!baseToken || sell !== baseToken || buy !== baseToken) {
+    return null;
+  }
+
+  const candidates = findCandidateCycles(snapshot, config.pathfinder || {});
+  if (candidates.length === 0) return null;
+
+  // Score by net-of-gas later; here pick the best-sized candidate as the route for this order.
+  let best = null;
+  for (const c of candidates) {
+    const sized = optimalInput(c.hops);
+    if (sized.grossProfitWei <= 0n) continue;
+    if (!best || sized.grossProfitWei > BigInt(best.grossProfitWei)) {
+      best = {
+        tokens: c.tokens,
+        hops: c.hops,
+        amountInWei: sized.amountIn.toString(),
+        amountOutWei: sized.amountOut.toString(),
+        grossProfitWei: sized.grossProfitWei.toString()
+      };
+    }
+  }
+  if (!best) return null;
+
+  // On-chain economic backstop: minAmountOut. By default we set it to amountIn — i.e. the
+  // contract only enforces that the route round-trips WHOLE (break-even, no on-chain profit
+  // floor). This is DELIBERATE: the REAL economic guard is the solver's OFF-CHAIN net-of-gas
+  // scoring (scoreRoute below). CoW will not submit a solution that loses, and a winning
+  // solution has already cleared config.scoring.minNetSurplusUsd before it is ever encoded, so
+  // the chain only needs to guard against a stale-reserve revert (out < in), not against a
+  // losing trade. Optionally tighten this with config.scoring.minOnchainProfitBps to also
+  // demand an on-chain profit floor (bps over amountIn) as defence-in-depth against bad
+  // off-chain scoring — 0 (break-even) by default.
+  const profitBps = BigInt((config.scoring && config.scoring.minOnchainProfitBps) || 0);
+  const amountIn = BigInt(best.amountInWei);
+  best.minAmountOutWei = (amountIn + (amountIn * profitBps) / 10000n).toString();
+  return best;
+}
+
+/**
+ * Net-of-gas score for a route, reusing the research gas model. Returns USD surplus after gas.
+ * @param {object} route
+ * @param {object} config
+ * @returns {{ grossUsd:number, gasUsd:number, netUsd:number, hopCount:number }}
+ */
+function scoreRoute(route, config) {
+  const gasCfg = config.gas || {};
+  const hopCount = route.hops.length;
+  const grossUsd = weiToUsd(BigInt(route.grossProfitWei), gasCfg.nativeUsdPrice);
+  // Fat executor: BofhContractV2 is the interaction contract, so price its gas (not lean).
+  const gas = gasCostForCycle(hopCount, gasCfg, 'bofhV2');
+  return { grossUsd, gasUsd: gas.costUsd, netUsd: grossUsd - gas.costUsd, hopCount };
+}
+
+/**
+ * Assemble a CoW Solution object for one fulfilled order + its Bofh interactions.
+ * Shape mirrors the solver openapi.yml: { id, prices, trades:[{kind:"fulfillment",...}],
+ * interactions:[{kind:"custom",...}], gas }.
+ * @param {number} id
+ * @param {object} order
+ * @param {object} route
+ * @param {object} score
+ * @param {object} config
+ * @param {number} deadline - unix seconds
+ * @returns {object} CoW Solution
+ */
+function buildSolution(id, order, route, score, config, deadline) {
+  const interactionContract = (config.interactionContract || {}).address;
+  const interactions = buildBofhInteractions(route, {
+    interactionContract,
+    deadline,
+    includeApprove: true,
+    useRegistryFees: true
+  });
+
+  // Clearing prices: for the baseToken round-trip the in/out token is the same; a 1:1 price
+  // entry is the minimal valid map. A real multi-token fill must price every traded token so
+  // CoW can verify uniform clearing (TODO when generic routing lands).
+  const prices = { [order.sellToken]: '1', [order.buyToken]: '1' };
+
+  return {
+    id,
+    prices,
+    trades: [
+      {
+        kind: 'fulfillment',
+        order: order.uid,
+        // sell-kind orders report executed SELL amount; buy-kind report executed BUY amount.
+        executedAmount: String(order.kind === 'buy' ? order.buyAmount : order.sellAmount)
+      }
+    ],
+    interactions,
+    // Estimated gas units for the whole interaction set (fat executor profile).
+    gas: gasCostForCycle(score.hopCount, config.gas || {}, 'bofhV2').gasUnits,
+    // Non-standard annotation for our own logs/inspection — CoW ignores unknown fields.
+    _bofhNetUsd: Number(score.netUsd.toFixed(6))
+  };
+}
+
+/**
+ * Parse + solve a CoW batch auction instance.
+ *
+ * @param {object} auction - CoW auction (id, tokens, orders[], effectiveGasPrice, deadline, ...).
+ * @param {object} ctx
+ * @param {object} ctx.config - solver config (see config.example.json).
+ * @param {object} ctx.snapshot - scanner.js-shaped pool snapshot (REAL reserves for a real run).
+ * @returns {{ solutions: object[] }} the CoW solution response body.
+ */
+function solve(auction, ctx) {
+  const { config, snapshot } = ctx;
+  if (!auction || !Array.isArray(auction.orders)) {
+    throw new Error('solve: auction.orders missing — not a CoW batch-auction instance.');
+  }
+  if (!snapshot) {
+    // Honest about the dependency: we route over reserves; without them there is nothing to do.
+    console.warn('[cow/solve] no pool snapshot provided — cannot route. (scanner.js needs RPC; see README.) Returning empty.');
+    return { solutions: [] };
+  }
+
+  const allow = allowSet(config);
+  const minNet = (config.scoring && config.scoring.minNetSurplusUsd) || 0;
+  // CoW deadline is ISO-8601; fall back to +60s. The contract reverts past this.
+  const deadline = auction.deadline
+    ? Math.floor(new Date(auction.deadline).getTime() / 1000)
+    : Math.floor(Date.now() / 1000) + 60;
+
+  const solutions = [];
+  let nextId = 0;
+
+  for (const order of auction.orders) {
+    if (!orderPassesAllowlist(order, allow)) continue; // token-safety gate (fail closed)
+
+    const route = routeOrder(order, snapshot, config);
+    if (!route) continue;
+
+    const score = scoreRoute(route, config);
+    if (score.netUsd <= 0 || score.netUsd < minNet) continue; // net-of-gas scorer is the gate
+
+    try {
+      solutions.push(buildSolution(nextId++, order, route, score, config, deadline));
+    } catch (err) {
+      // A bad encode (e.g. zero interaction-contract address) must NEVER yield a fake solution.
+      console.warn(`[cow/solve] skipped order ${order.uid}: ${err.message}`);
+    }
+  }
+
+  return { solutions };
+}
+
+/* --------------------------------------------------------------------------------------- *
+ * Runnable harness: `node solvers/cow/solve.js --demo`  builds a synthetic auction + the
+ * research demo snapshot and prints the solution JSON. No RPC, no driver, no keys.
+ * --------------------------------------------------------------------------------------- */
+
+/**
+ * Demo CoW auction whose single order is a baseToken round-trip over the research demo
+ * snapshot (so the cycle finder yields a route). Tokens are forced onto the allowlist.
+ * @param {object} snapshot
+ * @returns {object} auction
+ */
+function demoAuction(snapshot) {
+  const base = snapshot.baseToken;
+  return {
+    id: 'demo-auction-1',
+    tokens: { [base]: { decimals: 18, symbol: snapshot.baseTokenSymbol || 'WBASE' } },
+    orders: [
+      {
+        uid: '0x' + 'ab'.repeat(56),
+        sellToken: base,
+        buyToken: base,
+        sellAmount: (10n ** 18n).toString(),
+        buyAmount: (10n ** 18n).toString(),
+        fullBuyAmount: (10n ** 18n).toString(),
+        kind: 'sell',
+        partiallyFillable: false,
+        class: 'limit',
+        owner: '0x' + '11'.repeat(20),
+        validTo: Math.floor(Date.now() / 1000) + 3600,
+        signingScheme: 'eip712'
+      }
+    ],
+    effectiveGasPrice: '60000000', // 0.06 gwei, wei
+    deadline: new Date(Date.now() + 60_000).toISOString()
+  };
+}
+
+function mainDemo() {
+  const { config } = loadConfig();
+  // Reuse the research demo snapshot so the cycle finder has something to chew on.
+  const { demoSnapshot } = require('../../research/run.js');
+  const snapshot = demoSnapshot();
+
+  // Force the demo tokens onto the allowlist + a non-zero interaction contract so the
+  // scaffold can produce a sample solution end-to-end without real config.
+  const cfg = JSON.parse(JSON.stringify(config));
+  cfg.tokenAllowlist = { tokens: [snapshot.baseToken] };
+  cfg.interactionContract = { address: '0x' + '22'.repeat(20) };
+
+  const auction = demoAuction(snapshot);
+  const out = solve(auction, { config: cfg, snapshot });
+
+  console.log('[cow/solve --demo] auction orders:', auction.orders.length);
+  console.log('[cow/solve --demo] solutions:', out.solutions.length);
+  console.log(JSON.stringify(out, null, 2));
+  if (out.solutions.length === 0) {
+    console.log('\n[cow/solve --demo] NOTE: 0 solutions is a valid outcome (net-of-gas gate / demo reserves).');
+  }
+}
+
+if (require.main === module) {
+  const arg = process.argv[2];
+  try {
+    if (arg === '--demo') {
+      mainDemo();
+    } else if (arg) {
+      // Treat a positional arg as a path to a CoW auction JSON; snapshot via env SNAPSHOT_FILE.
+      const { config } = loadConfig();
+      const auction = JSON.parse(fs.readFileSync(arg, 'utf8'));
+      const snapFile = process.env.SNAPSHOT_FILE;
+      const snapshot = snapFile ? JSON.parse(fs.readFileSync(snapFile, 'utf8')) : null;
+      console.log(JSON.stringify(solve(auction, { config, snapshot }), null, 2));
+    } else {
+      console.log('usage: node solvers/cow/solve.js --demo   |   node solvers/cow/solve.js <auction.json>  (SNAPSHOT_FILE=<snapshot.json>)');
+    }
+  } catch (err) {
+    console.error('[cow/solve] fatal:', err.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  loadConfig,
+  allowSet,
+  orderPassesAllowlist,
+  routeOrder,
+  scoreRoute,
+  buildSolution,
+  solve,
+  demoAuction
+};


### PR DESCRIPTION
Off-chain implementation of the 2026 viability plays — the **prove-the-edge layer** that gates the on-chain Atlas solver (#45) before any audit spend. All off-chain (no contract change; hardhat suite unaffected).

## `research/` — Play #3 (long-tail/fresh-pool backrun on a PGA chain) + Play #4 (token-safety guard)
- **`tokenSafety.js`** (#4, the enabler): a **per-token** `base↔token` buy-then-sell probe (honeypot / sell-block / transfer-tax / max-tx / fee-flip), wired as a **HARD pre-fire drop gate** in the backtester (unsafe candidates dropped + counted, never fired). Forked-EVM re-simulation is a documented `simulateOnFork()` TODO seam; interior-token offline tax is honestly left `TAX-UNMEASURED`.
- **`freshPoolScanner.js`** (#3): `PairCreated`-replay enumeration of newly-created V2-fork pairs (age-filtered), in the same snapshot shape the pathfinder/backtester already consume.
- **`gasBidPolicy.js`** (#3): dynamic Priority-Gas-Auction bid policy (Monad / HyperEVM).
- **`sizing.js`** (#3): liquidity-capped CPMM optimal-input sizing (reserve + max-price-impact capped).
- `backtester` / `run` / `config` / `README` updated for the new stages, the Monad/HyperEVM PGA framing, and per-pool age + competitor fields.

## `solvers/cow/` — Play #2 (CoW Protocol solver-filler scaffold)
Honest runnable skeleton: reuses **`BofhContractV2` as the non-custodial interaction contract**, `pathfinder.js` as the solution engine, and the backtester net-of-gas as the scorer. README has the real onboarding runbook (shadow → KYC → staging → prod, ~25% bond, CIP-85 long-tail rewards, rewards-in-COW), and flags the limits plainly: **KYC kills anonymity**, **V2-only** loses V3/V4-deep solutions, the on-chain interaction enforces only break-even (real guard is the off-chain net-of-gas score), and **`antiMEV` would rate-limit a repeatedly-firing solver** (keep it disabled / sized for cadence). TODOs left for the real CoW driver/API/auth.

## Verification
- `node --check` on all `research/*.js` + `solvers/cow/*.js` ✅
- `node research/run.js --demo` and `node solvers/cow/solve.js --demo` run end-to-end ✅

> **This is where the edge gets proven.** The discipline stands: run the backtester KILL-criteria on real chain data → if GO, strip the executor → audit last (incl. the #45 solver as a new surface). A KILL means sunset that track, not an audit.